### PR TITLE
Fix une ligne de sous total entre 2 page s'insert mal

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -593,9 +593,8 @@ class ActionsSubtotal
 			$pdf->SetFillColor(230,230,230);
 		else
 			$pdf->SetFillColor(240,240,240);
-		
 		$pdf->SetFont('', 'B', 9);
-
+		
 		$pdf->writeHTMLCell($w, $h, $posx, $posy, $label, 0, 1, false, true, 'R',true);
 //		var_dump($bMargin);
 		$pageAfter = $pdf->getPage();
@@ -667,6 +666,7 @@ class ActionsSubtotal
 			$pdf->writeHTMLCell($w, $h, $posx, $posy, $description, 0, 1, false, true, 'J',true);
 
 		}
+		
 	}
 
 	function pdf_writelinedesc_ref($parameters=array(), &$object, &$action='') {
@@ -938,17 +938,17 @@ class ActionsSubtotal
 					$pageBefore = $pdf->getPage();
 					$this->pdf_add_total($pdf,$object, $line, $label, $description,$posx, $posy, $w, $h);
 					$pageAfter = $pdf->getPage();	
-/*
+
 					if($pageAfter>$pageBefore) {
-						print "ST $pageAfter>$pageBefore<br>";
+						//print "ST $pageAfter>$pageBefore<br>";
 						$pdf->rollbackTransaction(true);	
 						$pdf->addPage('','', true);
 						$posy = $pdf->GetY();
 						$this->pdf_add_total($pdf,$object, $line, $label, $description,$posx, $posy, $w, $h);
 						$posy = $pdf->GetY();
-						print 'add ST'.$pdf->getPage().'<br />';
+						//print 'add ST'.$pdf->getPage().'<br />';
 					}
-	*/				
+				
 					$posy = $pdf->GetY();
 					
 				}	
@@ -958,6 +958,7 @@ class ActionsSubtotal
 					$this->pdf_add_title($pdf,$object, $line, $label, $description,$posx, $posy, $w, $h); 
 					$pageAfter = $pdf->getPage();	
 
+					
 					/*if($pageAfter>$pageBefore) {
 						print "T $pageAfter>$pageBefore<br>";
 						$pdf->rollbackTransaction(true);


### PR DESCRIPTION
Le problème vient de l'affichage d'une ligne de sous-total entre 2 pages

Je sais pas comment expliquer ça clairement, mais en gros l'impression du background et le texte "sous-total" n'est pas inclue dans le rollback fait par le PDF mais le prix lui est bien effacé pour être imprimé sur la bonne page.
En remettant le rollback qu'on faisais avant ça s'affiche nickel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_subtotal/29)
<!-- Reviewable:end -->
