### PR TITLE
FIX compatibility with module 'Shippable orders'

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1314,6 +1314,7 @@ class ActionsSubtotal
 			
 			$colspan = 5;
 			if(!empty($conf->multicurrency->enabled)) $colspan+=2;
+			if(!empty($conf->shippableorder->enabled)) $colspan++;
 			if(!empty($conf->clisms->enabled)) $colspan+=3;
 			if(!empty($conf->margin->enabled)) $colspan++;
 			if(!empty($conf->global->DISPLAY_MARGIN_RATES)) $colspan++;

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1314,6 +1314,7 @@ class ActionsSubtotal
 			
 			$colspan = 5;
 			if(!empty($conf->multicurrency->enabled)) $colspan+=2;
+			if(!empty($conf->clisms->enabled)) $colspan+=3;
 			if(!empty($conf->margin->enabled)) $colspan++;
 			if(!empty($conf->global->DISPLAY_MARGIN_RATES)) $colspan++;
 			if(!empty($conf->global->DISPLAY_MARK_RATES)) $colspan++;

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1315,7 +1315,6 @@ class ActionsSubtotal
 			$colspan = 5;
 			if(!empty($conf->multicurrency->enabled)) $colspan+=2;
 			if(!empty($conf->shippableorder->enabled)) $colspan++;
-			if(!empty($conf->clisms->enabled)) $colspan+=3;
 			if(!empty($conf->margin->enabled)) $colspan++;
 			if(!empty($conf->global->DISPLAY_MARGIN_RATES)) $colspan++;
 			if(!empty($conf->global->DISPLAY_MARK_RATES)) $colspan++;


### PR DESCRIPTION
Increment colspan when module 'Shippable orders' is activated to avoid column shifts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_subtotal/47)
<!-- Reviewable:end -->
