### PR TITLE
New conf pour clôturer les titres

### DIFF
--- a/admin/subtotal_setup.php
+++ b/admin/subtotal_setup.php
@@ -307,7 +307,7 @@ function showParameters() {
 	<br />
 		
 	<table width="100%" class="noborder" style="background-color: #fff;">
-		<!--<tr class="liste_titre">-->
+		<tr class="liste_titre">
 			<td colspan="2">Paramètrage de l'option "Cacher le prix des lignes des ensembles"</td>
 		</tr>
 		

--- a/admin/subtotal_setup.php
+++ b/admin/subtotal_setup.php
@@ -248,6 +248,13 @@ function showParameters() {
 		print '</td></tr>';
 	}
 	
+	$var=!$var;
+	print '<tr '.$bc[$var].'>';
+	print '<td>'.$langs->trans('SUBTOTAL_AUTO_ADD_SUBTOTAL_ON_ADDING_NEW_TITLE').'</td>';
+	print '<td align="center" width="20">&nbsp;</td>';
+	print '<td align="center" width="300">';
+	print ajax_constantonoff('SUBTOTAL_AUTO_ADD_SUBTOTAL_ON_ADDING_NEW_TITLE');
+	print '</td></tr>';
 	
 	print '</table><br />';
 	
@@ -300,7 +307,7 @@ function showParameters() {
 	<br />
 		
 	<table width="100%" class="noborder" style="background-color: #fff;">
-		<tr class="liste_titre">
+		<!--<tr class="liste_titre">-->
 			<td colspan="2">Paramètrage de l'option "Cacher le prix des lignes des ensembles"</td>
 		</tr>
 		

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -64,6 +64,9 @@ class ActionsSubtotal
 						$qty = $level ? 100-$level : 99;
 					}
 					dol_include_once('/subtotal/class/subtotal.class.php');
+					
+					if (!empty($conf->global->SUBTOTAL_AUTO_ADD_SUBTOTAL_ON_ADDING_NEW_TITLE) && $qty < 10) TSubtotal::addSubtotalMissing($object, $qty);
+					
 	    			TSubtotal::addSubTotalLine($object, $title, $qty);
 				}
 				else if($action==='ask_deleteallline') {

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -559,7 +559,7 @@ class ActionsSubtotal
 				if (!$return_all) return $total;
 				else return array($total, $total_tva, $total_ttc, $TTotal_tva);
 			}
-			else if(TSubtotal::isTitle($l)) 
+			else if(TSubtotal::isTitle($l, 100 - $qty_line)) 
 		  	{
 				$total = 0;
 				$total_tva = 0;

--- a/class/subtotal.class.php
+++ b/class/subtotal.class.php
@@ -164,9 +164,13 @@ class TSubtotal {
 		return false;
 	}
 	
-	public static function isTitle(&$line)
+	public static function isTitle(&$line, $level=-1)
 	{
-		return $line->special_code == self::$module_number && $line->product_type == 9 && $line->qty <= 9;
+		$res = $line->special_code == self::$module_number && $line->product_type == 9 && $line->qty <= 9;
+		if($res && $level > -1) {
+			return $line->qty == $level;
+		} else return $res;
+		
 	}
 	
 	public static function isSubtotal(&$line)

--- a/class/subtotal.class.php
+++ b/class/subtotal.class.php
@@ -41,6 +41,13 @@ class TSubtotal {
 	
 	}
 	
+	/**
+	 * Permet de mettre à jour les rangs afin de décaler des lignes pour une insertion en milieu de document
+	 * 
+	 * @param type $object
+	 * @param type $rang_start
+	 * @param type $move_to
+	 */
 	public static function updateRang(&$object, $rang_start, $move_to=1)
 	{
 		if (!class_exists('GenericObject')) require_once DOL_DOCUMENT_ROOT.'/core/class/genericobject.class.php';
@@ -58,6 +65,13 @@ class TSubtotal {
 		}
 	}
 	
+	/**
+	 * Méthode qui se charge de faire les ajouts de sous-totaux manquant afin de fermer les titres ouvert lors de l'ajout d'un nouveau titre
+	 * 
+	 * @global type $langs
+	 * @param type $object
+	 * @param type $level_new_title
+	 */
 	public static function addSubtotalMissing(&$object, $level_new_title)
 	{
 		global $langs;
@@ -86,14 +100,6 @@ class TSubtotal {
 				}
 			}
 		}
-	}
-
-	private static function orderByRang($a,$b)
-	{
-		if ($a->rang < $b->rang) return -1;
-		elseif ($a->rang > $b->rang) return 1;
-		
-		return 0;
 	}
 	
 	public static function addTitle(&$object, $label, $level, $rang=-1)
@@ -127,6 +133,7 @@ class TSubtotal {
 	}
 	
 	/**
+	 * Est-ce que mon titre ($title_line) a un sous-total ?
 	 * 
 	 * @param Propal|Commande|Facture				$object
 	 * @param PropaleLigne|OrderLine|FactureLigne	$title_line

--- a/class/subtotal.class.php
+++ b/class/subtotal.class.php
@@ -40,7 +40,62 @@ class TSubtotal {
 		}
 	
 	}
+	
+	public static function updateRang(&$object, $rang_start, $move_to=1)
+	{
+		if (!class_exists('GenericObject')) require_once DOL_DOCUMENT_ROOT.'/core/class/genericobject.class.php';
+		
+		$row=new GenericObject($object->db);
+		$row->table_element_line = $object->table_element_line;
+		$row->fk_element = $object->fk_element;
+		$row->id = $object->id;
+		
+		foreach ($object->lines as &$line)
+		{
+			if ($line->rang < $rang_start) continue;
+			
+			$row->updateRangOfLine($line->id, $line->rang+$move_to);
+		}
+	}
+	
+	public static function addSubtotalMissing(&$object, $level_new_title)
+	{
+		global $langs;
+		$TTitle = self::getAllTitleWithoutTotalFromDocument($object);
+		// Reverse - Pour partir de la fin et remonter dans les titres pour me permettre de m'arrêter quand je trouve un titre avec un niveau inférieur à celui qui a était ajouté
+		$TTitle_reverse = array_reverse($TTitle);
+		
+		foreach ($TTitle_reverse as $k => $title_line)
+		{
+			$title_niveau = self::getNiveau($title_line);
+			if ($title_niveau < $level_new_title) break;
+			
+			$rang_to_add = self::titleHasTotalLine($object, $title_line, true, true);
+			
+			if (is_numeric($rang_to_add)) 
+			{
+				if ($rang_to_add != -1) self::updateRang($object, $rang_to_add);
+				
+				self::addSubTotalLine($object, $langs->trans('SubTotal'), 100-$title_niveau, $rang_to_add);
+				
+				$object->lines[] = $object->line; // ajout de la ligne dans le tableau de ligne (Dolibarr ne le fait pas)
+				if ($rang_to_add != -1) 
+				{
+					if (method_exists($object, 'fetch_lines')) $object->fetch_lines();
+					else $object->fetch($object->id);
+				}
+			}
+		}
+	}
 
+	private static function orderByRang($a,$b)
+	{
+		if ($a->rang < $b->rang) return -1;
+		elseif ($a->rang > $b->rang) return 1;
+		
+		return 0;
+	}
+	
 	public static function addTitle(&$object, $label, $level, $rang=-1)
 	{
 		self::addSubTotalLine($object, $label, $level, $rang);
@@ -51,6 +106,60 @@ class TSubtotal {
 		self::addSubTotalLine($object, $label, (100-$level), $rang);
 	}
 
+	/**
+	 * Récupère la liste des lignes de titre qui n'ont pas de sous-total
+	 * 
+	 * @param Propal|Commande|Facture				$object
+	 * @param boolean								$get_block_total
+	 * 
+	 * @return array
+	 */
+	public static function getAllTitleWithoutTotalFromDocument(&$object, $get_block_total=false)
+	{
+		$TTitle = self::getAllTitleFromDocument($object, $get_block_total);
+		
+		foreach ($TTitle as $k => $title_line)
+		{
+			if (self::titleHasTotalLine($object, $title_line)) unset($TTitle[$k]);
+		}
+		
+		return $TTitle;
+	}
+	
+	/**
+	 * 
+	 * @param Propal|Commande|Facture				$object
+	 * @param PropaleLigne|OrderLine|FactureLigne	$title_line
+	 * @param boolean								$strict_mode			si true alors un titre doit avoir un sous-total de même niveau; si false un titre possède un sous-total à partir du moment où l'on trouve un titre de niveau égale ou inférieur
+	 * @param boolean								$return_rang_on_false	si true alors renvoi le rang où devrait ce trouver le sous-total
+	 * @return boolean
+	 */
+	public static function titleHasTotalLine(&$object, &$title_line, $strict_mode=false, $return_rang_on_false=false)
+	{
+		if (empty($object->lines) || !is_array($object->lines)) return false;
+		
+		$title_niveau = self::getNiveau($title_line);
+		foreach ($object->lines as &$line)
+		{
+			if ($line->rang <= $title_line->rang) continue;
+			if (self::isTitle($line) && self::getNiveau($line) <= $title_niveau) return false; // Oups on croise un titre d'un niveau inférieur ou égale (exemple : je croise un titre niveau 2 alors que je suis sur un titre de niveau 3) pas lieu de continuer car un nouveau bloc commence
+			if (!self::isSubtotal($line)) continue;
+			
+			$subtotal_niveau = self::getNiveau($line);
+			
+			// Comparaison du niveau de la ligne de sous-total avec celui du titre
+			if ($subtotal_niveau == $title_niveau) return true; // niveau égale => Ok mon titre a un sous-total
+			elseif ($subtotal_niveau < $title_niveau) // niveau inférieur trouvé (exemple : sous-total de niveau 1 contre mon titre de niveau 3)
+			{
+				if ($strict_mode) return ($return_rang_on_false) ? $line->rang : false; // mode strict niveau pas égale donc faux
+				else return true; // mode libre => OK je considère que mon titre à un sous-total
+			}
+		}
+		
+		// Sniff, j'ai parcouru toutes les lignes et pas de sous-total pour ce titre
+		return ($return_rang_on_false) ? -1 : false;
+	}
+	
 	public static function getAllTitleFromDocument(&$object, $get_block_total=false)
 	{
 		$TRes = array();

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -63,7 +63,7 @@ class modSubtotal extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Module permettant l'ajout de sous-totaux et sous-totaux intermédiaires et le déplacement d'une ligne aisée de l'un dans l'autre";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '2.1.0';
+        $this->version = '2.2.0';
         // Key used in llx_const table to save module status enabled/disabled
         // (where MYMODULE is value of property name of module in uppercase)
         $this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/langs/en_US/subtotal.lang
+++ b/langs/en_US/subtotal.lang
@@ -61,3 +61,4 @@ SUBTOTAL_COMMANDE_ADD_RECAP=Enable the generation of summary on orders
 SUBTOTAL_INVOICE_ADD_RECAP=Enable the generation of summary on invoices
 warning_subtotal_recap_object_element_unknown=Can't generate the summary by title, unknown element: %s
 subtotal_add_recap=Add the summary by title
+SUBTOTAL_AUTO_ADD_SUBTOTAL_ON_ADDING_NEW_TITLE=Add a new title will add above the missing subtotals

--- a/langs/fr_FR/subtotal.lang
+++ b/langs/fr_FR/subtotal.lang
@@ -62,3 +62,4 @@ SUBTOTAL_INVOICE_ADD_RECAP=Activer la génération du récapitulatif sur les fac
 warning_subtotal_recap_object_element_unknown=Génération du récapitulatif impossible, element inconnu : %s
 subtotal_add_recap=Ajouter le récapitulatif
 AddFreeText = Ajouter une ligne de texte
+SUBTOTAL_AUTO_ADD_SUBTOTAL_ON_ADDING_NEW_TITLE=Ajouter un titre, ajoutera au-dessus les sous-totaux manquants


### PR DESCRIPTION
Lors d'un ajout de titre, il y a une vérification qui ajoutera automatiquement des sous-totaux au-dessus du nouveau titre afin de clôturer les blocs précédent ouvert (sans sous-total)

T1
  T2
    T3
      T4
      ST4

Si ajout d'un titre T2bis
- add ST3 et ST2

Si ajout d'un titre T1bis
- add ST3 et ST2 et ST1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_subtotal/50)
<!-- Reviewable:end -->
