### PR TITLE
Fix label and desc switch for dolibar > 6.0

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1443,7 +1443,8 @@ class ActionsSubtotal
 				
 				$label = $line->label;
 				$description= !empty($line->desc) ? $outputlangs->convToOutputCharset($line->desc) : $outputlangs->convToOutputCharset($line->description);
-				if(empty($label)) {
+				
+				if(empty($label) && (float)DOL_VERSION < 6.0) {
 					$label = $description;
 					$description='';
 				}

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1226,7 +1226,7 @@ class ActionsSubtotal
 			{
 				$TTitle[$j]['numerotation'] = ($prefix_num == 0) ? $i : $prefix_num.'.'.$i;
 				//var_dump('Prefix == '.$prefix_num.' // '.$line->desc.' ==> numerotation == '.$TTitle[$j]['numerotation'].'   ###    '.$line->qty .'=='. $level);
-				if (empty($line->label))
+				if (empty($line->label) && (float)DOL_VERSION < 6)
 				{
 					$line->label = !empty($line->desc) ? $line->desc : $line->description;
 					$line->desc = $line->description = '';
@@ -1662,11 +1662,11 @@ class ActionsSubtotal
 						if($line->label=='' && !$isFreeText) {
 							if(TSubtotal::isSubtotal($line)) {
 								$newlabel = $line->description.' '.$this->getTitle($object, $line);
-							} else {
+								$line->description='';
+							} elseif( (float)DOL_VERSION < 6 ) {
 								$newlabel= $line->description;
+								$line->description='';
 							}
-							$line->label = $newlabel;
-							$line->description='';
 						}
 
 						if (!$isFreeText) echo '<input type="text" name="line-title" id-line="'.$line->id.'" value="'.$line->label.'" size="80"/>&nbsp;';

--- a/class/subtotal.class.php
+++ b/class/subtotal.class.php
@@ -699,7 +699,12 @@ class TSubtotal {
 				$decalage = (self::getNiveau($line) - 1) * 2;
 				
 				// Print: Designation
-				$label = !empty($line->label) ? $line->label : $line->desc;
+				$label = $line->label;
+				if( (float)DOL_VERSION < 6 ) {
+					$label = !empty($line->label) ? $line->label : $line->desc;
+				}
+				
+				
 				$pdf->startTransaction();
 				$pdf->writeHTMLCell($posx_options-$posx_designation-$decalage, 3, $posx_designation+$decalage, $curY, $outputlangs->convToOutputCharset($label), 0, 1, false, true, 'J',true);
 				$pageposafter=$pdf->getPage();


### PR DESCRIPTION
Rectification du comportement des lignes "titre" lorsque le champ `label` est vide: la description ne viens plus remplacer le `label`.
Le problème était visible avec le wyswyg: les balises html dans le label passaient pas bien dans les PDF, les ODT , etc...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_subtotal/76)
<!-- Reviewable:end -->
