### PR TITLE
fix du fix de @atm-john  ;)

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1444,7 +1444,7 @@ class ActionsSubtotal
 				$label = $line->label;
 				$description= !empty($line->desc) ? $outputlangs->convToOutputCharset($line->desc) : $outputlangs->convToOutputCharset($line->description);
 				
-				if(empty($label) ) {
+				if(empty($label) && $description== strip_tags($description)) {
 					$label = $description;
 					$description='';
 				}

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1444,7 +1444,7 @@ class ActionsSubtotal
 				$label = $line->label;
 				$description= !empty($line->desc) ? $outputlangs->convToOutputCharset($line->desc) : $outputlangs->convToOutputCharset($line->description);
 				
-				if(empty($label) && (float)DOL_VERSION < 6.0) {
+				if(empty($label) ) {
 					$label = $description;
 					$description='';
 				}


### PR DESCRIPTION
Les lignes de sous total & de titre étaient défectueuses sur les documents pdf ex: crabe ou azur

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_subtotal/78)
<!-- Reviewable:end -->
