### PR TITLE
Fix #64 bug ajout d'une ligne de texte avec le wyziwyg d'activé

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -229,7 +229,7 @@ class ActionsSubtotal
 	                        buttons: {
 	                            "Ok": function() {
 	                            	if (typeof use_textarea != 'undefined' && use_textarea && typeof CKEDITOR == "object" && typeof CKEDITOR.instances != "undefined" ){ updateAllMessageForms(); }
-									params.title = $(this).find('#sub-total-title').val();
+									params.title = params.title = (typeof CKEDITOR == "object" && typeof CKEDITOR.instances != "undefined" && "sub-total-title" in CKEDITOR.instances ? CKEDITOR.instances["sub-total-title"].getData() : $(this).find('#sub-total-title').val());
 									params.under_title = $(this).find('select[name=under_title]').val();
 									params.free_text = $(this).find('select[name=free_text]').val();
 									params.level = $(this).find('select[name=subtotal_line_level]').val();


### PR DESCRIPTION
fixes #64: ajout d'une ligne de texte avec le wyziwyg d'activé dont le texte n'était pas récupéré.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_subtotal/80)
<!-- Reviewable:end -->
