### PR TITLE
Fix title wysiwyg with title style config

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1631,7 +1631,7 @@ class ActionsSubtotal
 
 			?>;">
 			
-				<td colspan="<?php echo $colspan; ?>" style="<?php TSubtotal::isFreeText($line) ? '' : 'font-weight:bold;'; ?>  <?php echo ($line->qty>90)?'text-align:right':' font-style: italic;' ?> "><?php
+				<td colspan="<?php echo $colspan; ?>" style="<?php TSubtotal::isFreeText($line) ? '' : 'font-weight:bold;'; ?>  <?php echo ($line->qty>90)?'text-align:right':'' ?> "><?php
 					if($action=='editline' && GETPOST('lineid') == $line->id && TSubtotal::isModSubtotalLine($line) ) {
 
 						$params=array('line'=>$line);
@@ -1740,6 +1740,12 @@ class ActionsSubtotal
 							else if($line->qty==2) print img_picto('', 'subsubtotal@subtotal').'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'; 
 						 }
 						 
+						 
+						 // Get display styles and apply them
+						 $titleStyleItalic = strpos($conf->global->SUBTOTAL_TITLE_STYLE, 'I') === false ? '' : ' font-style: italic;';
+						 $titleStyleBold =  strpos($conf->global->SUBTOTAL_TITLE_STYLE, 'B') === false ? '' : ' font-weight:bold;';
+						 $titleStyleUnderline =  strpos($conf->global->SUBTOTAL_TITLE_STYLE, 'U') === false ? '' : ' text-decoration: underline;';
+						 
 						 if (empty($line->label)) {
 							if ($line->qty >= 91 && $line->qty <= 99 && $conf->global->SUBTOTAL_USE_NEW_FORMAT) print  $line->description.' '.$this->getTitle($object, $line);
 							else print  $line->description;
@@ -1747,10 +1753,10 @@ class ActionsSubtotal
 						 else {
 
 							if (! empty($conf->global->PRODUIT_DESC_IN_FORM) && !empty($line->description)) {
-								print $line->label.'<br><span style="font-weight:normal;">'.dol_htmlentitiesbr($line->description).'</span>';
+								print '<span class="subtotal_label" style="'.$titleStyleItalic.$titleStyleBold.$titleStyleUnderline.'" >'.$line->label.'</span><br><div class="subtotal_desc">'.dol_htmlentitiesbr($line->description).'</div>';
 							}
 							else{
-								print '<span class="classfortooltip" title="'.$line->description.'">'.$line->label.'</span>';    
+								print '<span class="subtotal_label classfortooltip '.$titleStyleItalic.$titleStyleBold.$titleStyleUnderline.'" title="'.$line->description.'">'.$line->label.'</span>';    
 							}
 
 						 } 


### PR DESCRIPTION
Petit correctif visuel pour l'internaute utilisant le wysiwyg

Ce correctif permet d'afficher sur une ligne de titre, le style correspondant à la config du module:
 "Style des titres (B = gras, U = souligné, I = italique)"

La description du titre n'est plus forcée en italic pour respecter les styles appliqués par le wysiwyg.

la description n'est plus dans un "span" mais dans une "div" ( c'est plus propre avec le code générer par le wysiwyg).

J'ai aussi ajouter 2 class pour les lignes de sous total.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_subtotal/83)
<!-- Reviewable:end -->
