### PR TITLE
FIX : taux tva on progress change

### DIFF
--- a/lib/subtotal.lib.php
+++ b/lib/subtotal.lib.php
@@ -157,6 +157,7 @@ function _updateSubtotalBloc($object, $line)
 		$TLine = TSubtotal::getLinesFromTitleId($object, $line->id);
 		foreach ($TLine as &$line)
 		{
+
 			if (!TSubtotal::isTitle($line) && !TSubtotal::isSubtotal($line))
 			{
 				if (!empty($showBlockExtrafields)) $line->array_options = $array_options;
@@ -176,6 +177,8 @@ function _updateSubtotalBloc($object, $line)
 				}
 				
 				$res = TSubtotal::doUpdateLine($object, $line->id, $line->desc, $line->subprice, $line->qty, $line->remise_percent, $line->date_start, $line->date_end, $subtotal_tva_tx, $line->product_type, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->fk_parent_line, $line->skip_update_total, $line->fk_fournprice, $line->pa_ht, $line->label, $line->special_code, $line->array_options, $subtotal_progress, $line->fk_unit);
+
+				$subtotal_tva_tx = '';	// La valeur présente dans la variable écrasait le taux de tva des autres lignes
 
 				if ($res > 0) $success_updated_line++;
 				else $error_updated_line++;


### PR DESCRIPTION
Si on change la progression d'un titre, les taux de tva des produits changeaient pour le taux du 1er produit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_subtotal/89)
<!-- Reviewable:end -->
