### PR TITLE
Fix free text truncate on add

### DIFF
--- a/class/subtotal.class.php
+++ b/class/subtotal.class.php
@@ -25,7 +25,7 @@ class TSubtotal {
 		}
 		else {
 			$desc = '';
-			if ((float) DOL_VERSION < 6) {
+			if ((float) DOL_VERSION < 6  || $qty==50) {
 				$desc = $label;
 				$label = '';
 			}


### PR DESCRIPTION
Lors de l'ajout d'une ligne de texte, sous total enregistre la description dans la colonne label en bdd... au lieu de description du coup si le texte est long (+ de 255 char) le texte est tronqué.

bug aussi présent en 3.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_subtotal/107)
<!-- Reviewable:end -->
