### PR TITLE
Ajout d'une option

### DIFF
--- a/admin/subtotal_setup.php
+++ b/admin/subtotal_setup.php
@@ -336,6 +336,14 @@ function showParameters() {
 			<td colspan="2">Paramètrage de l'option "Cacher le prix des lignes des ensembles"</td>
 		</tr>
 		
+<?php 
+	print '<tr class="oddeven" >';
+	print '<td>'.$langs->trans('SUBTOTAL_HIDE_PRICE_DEFAULT_CHECKED').'</td>';
+	print '<td align="center" >';
+	print ajax_constantonoff('SUBTOTAL_HIDE_PRICE_DEFAULT_CHECKED');
+	print '</td></tr>';
+?>
+
 		<tr>
 			<td>Afficher la quantité sur les lignes de produit</td>
 			<td style="text-align: right;">

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -350,7 +350,8 @@ class ActionsSubtotal
 	        {	
 				$hideInnerLines	= isset( $_SESSION['subtotal_hideInnerLines_'.$parameters['modulepart']] ) ?  $_SESSION['subtotal_hideInnerLines_'.$parameters['modulepart']] : 0;
 				$hidedetails	= isset( $_SESSION['subtotal_hidedetails_'.$parameters['modulepart']] ) ?  $_SESSION['subtotal_hidedetails_'.$parameters['modulepart']] : 0;
-				$hideprices= isset( $_SESSION['subtotal_hideprices_'.$parameters['modulepart']] ) ?  $_SESSION['subtotal_hideprices_'.$parameters['modulepart']] : 0;
+				$hidepricesDefaultConf = !empty($conf->global->SUBTOTAL_HIDE_PRICE_DEFAULT_CHECKED)?$conf->global->SUBTOTAL_HIDE_PRICE_DEFAULT_CHECKED:0;
+				$hideprices= isset( $_SESSION['subtotal_hideprices_'.$parameters['modulepart']] ) ?  $_SESSION['subtotal_hideprices_'.$parameters['modulepart']] : $hidepricesDefaultConf;
 				
 				$var=false;
 		     	$out.= '<tr '.$bc[$var].'>

--- a/langs/fr_FR/subtotal.lang
+++ b/langs/fr_FR/subtotal.lang
@@ -37,6 +37,7 @@ SUBTOTAL_TITLE_STYLE=Style des titres (B = gras, U = souligné, I = italique)
 SUBTOTAL_SUBTOTAL_STYLE=Style des sous-totaux (B = gras, U = souligné, I = italique)
 SUBTOTAL_ONE_LINE_IF_HIDE_INNERLINES=Avoir une seule ligne de titre + total si l'option "%s" est utilisée (expérimental)
 SUBTOTAL_REPLACE_WITH_VAT_IF_HIDE_INNERLINES=Remplacer par le détail des TVA si l'option "%s" est utilisée (expérimental)
+SUBTOTAL_HIDE_PRICE_DEFAULT_CHECKED=Par defaut, cocher la case "Cacher le prix des lignes des ensembles" lors de la génération des PDF
 Duplicate=Dupliquer
 subtotal_duplicate_success=%d lignes dupliquées
 subtotal_duplicate_lineid_not_found=Impossible de dupliquer le bloc, l'identifiant du titre est introuvable


### PR DESCRIPTION
Par defaut, cocher la case "Cacher le prix des lignes des ensembles" lors de la génération des PDF

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_subtotal/111)
<!-- Reviewable:end -->
