### PR TITLE
Fix option : Cacher le prix des lignes des ensembles

### DIFF
--- a/admin/subtotal_setup.php
+++ b/admin/subtotal_setup.php
@@ -353,7 +353,7 @@ function showParameters() {
 					<?php echo $html->selectyesno("SUBTOTAL_IF_HIDE_PRICES_SHOW_QTY",$conf->global->SUBTOTAL_IF_HIDE_PRICES_SHOW_QTY,1); ?>
 					<input type="submit" class="button" value="<?php echo $langs->trans("Modify") ?>">
 				</form>
-			</td>				
+			</td>
 		</tr>
 		
 		<tr class="pair">

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1044,7 +1044,7 @@ class ActionsSubtotal
 	}
 	
 	function pdf_getlinetotalexcltax($parameters=array(), &$object, &$action='') {
-		global $conf, $hideprices;
+	    global $conf, $hideprices;
 		
 		if($this->isModSubtotalLine($parameters,$object) ){
 			
@@ -1093,8 +1093,17 @@ class ActionsSubtotal
 		{
 		    if (!empty($hideprices) || !in_array(__FUNCTION__, explode(',', $conf->global->SUBTOTAL_TFIELD_TO_KEEP_WITH_NC)))
 		    {
-		        $this->resprints = ' ';
-		        return 1;
+		        
+		        if(is_array($parameters)) $i = & $parameters['i'];
+		        else $i = (int)$parameters;
+		        
+		        // Check if a title exist for this line && if the title have subtotal
+		        $lineTitle = TSubtotal::getParentTitleOfLine($object, $i);
+		        if(TSubtotal::getParentTitleOfLine($object, $i) && TSubtotal::titleHasTotalLine($object, $lineTitle, true))
+		        {
+		            $this->resprints = ' ';
+		            return 1;
+		        }
 		    }
 		}
         

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1091,7 +1091,7 @@ class ActionsSubtotal
 		    || (!empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS) && (!empty($object->lines[$i]->array_options['options_subtotal_nc']) || TSubtotal::hasNcTitle($object->lines[$i])) )
 		    )
 		{
-		    if (!empty($hideprices) || !in_array(__FUNCTION__, explode(',', $conf->global->SUBTOTAL_TFIELD_TO_KEEP_WITH_NC)))
+		    if (!empty($hideprices))
 		    {
 		        
 		        if(is_array($parameters)) $i = & $parameters['i'];
@@ -1104,6 +1104,11 @@ class ActionsSubtotal
 		            $this->resprints = ' ';
 		            return 1;
 		        }
+		    }
+		    elseif (!in_array(__FUNCTION__, explode(',', $conf->global->SUBTOTAL_TFIELD_TO_KEEP_WITH_NC)))
+		    {
+		        $this->resprints = ' ';
+		        return 1;
 		    }
 		}
         


### PR DESCRIPTION
Ce fix permet de ne plus cacher des lignes ne faisant pas parties d'un ensemble...

j'e n'ai pas fix direct au cas ou il existe une contre indication. (si pas de contre indication je merge ;-) )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_subtotal/112)
<!-- Reviewable:end -->
