### PR TITLE
Add new hook for hideprices case

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1044,7 +1044,7 @@ class ActionsSubtotal
 	}
 	
 	function pdf_getlinetotalexcltax($parameters=array(), &$object, &$action='') {
-	    global $conf, $hideprices;
+	    global $conf, $hideprices, $hookmanager;
 		
 		if($this->isModSubtotalLine($parameters,$object) ){
 			
@@ -1101,8 +1101,34 @@ class ActionsSubtotal
 		        $lineTitle = TSubtotal::getParentTitleOfLine($object, $i);
 		        if(TSubtotal::getParentTitleOfLine($object, $i) && TSubtotal::titleHasTotalLine($object, $lineTitle, true))
 		        {
+		            
 		            $this->resprints = ' ';
+		            
+		            $reshook=$hookmanager->executeHooks('subtotalHidePrices',$parameters,$object,$action);
+		            
+		            if ($reshook < 0)
+		            {
+		                setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+		                return -1;
+		            }
+		            elseif (empty($reshook))
+		            {
+		                $this->resprints .= $hookmanager->resprints;
+		            }
+		            else
+		            {
+		                $this->resprints = $hookmanager->resprints;
+		                
+		                // override return (use  $this->results['overrideReturn'] or $this->resArray['overrideReturn'] in other module action_xxxx.class.php )
+		                if(isset($hookmanager->resArray['overrideReturn']))
+		                {
+		                    return $hookmanager->resArray['overrideReturn'];
+		                }
+		            }
+		            
 		            return 1;
+		            
+		            
 		        }
 		    }
 		    elseif (!in_array(__FUNCTION__, explode(',', $conf->global->SUBTOTAL_TFIELD_TO_KEEP_WITH_NC)))


### PR DESCRIPTION
Ajout d'un hook utilisable lorsque le prix d'une ligne est masqué par l'option  "Cacher le prix des lignes des ensembles".

Du coup ça permet d'usurper le comportement originale pour des lignes spécifiques: ainsi  il est possible _"d’empêcher de masquer le prix le prix"_ ou d'afficher simplement un texte.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_subtotal/113)
<!-- Reviewable:end -->
