### PR TITLE
NEW : Conf to show more informations on subtotal lines

### DIFF
--- a/class/subtotal.class.php
+++ b/class/subtotal.class.php
@@ -288,6 +288,7 @@ class TSubtotal {
 			else
 			{
 				$TTot['total_pa_ht'] += $l->pa_ht * $l->qty;
+				$TTot['total_subprice'] += $l->subprice * $l->qty;
 				$TTot['total_ht'] += $l->total_ht;
 				$TTot['total_tva'] += $l->total_tva;
 				$TTot['total_ttc'] += $l->total_ttc;

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -452,7 +452,7 @@ class modSubtotal extends DolibarrModules
      */
     public function init($options = '')
     {
-	  	global $conf;
+	  	global $conf, $db;
 		
 		
 /*		if($conf->milestone->enabled) {
@@ -462,7 +462,14 @@ class modSubtotal extends DolibarrModules
 	    $sql = array();
 
         $result = $this->loadTables();
-
+        dol_include_once('/core/class/extrafields.class.php');
+	
+        $extra = new ExtraFields($db); // propaldet, commandedet, facturedet
+        $TElementType = array('propaldet', 'commandedet', 'facturedet', 'supplier_proposaldet', 'commande_fournisseurdet', 'facture_fourn_det');
+        foreach($TElementType as $element_type) {
+            $extra->addExtraField('show_total_ht', 'Afficher le Total HT sur le sous-total', 'int', 0, 10, $element_type, 0, 0, '', unserialize('a:1:{s:7:"options";a:1:{s:0:"";N;}}'), 0, '', 0, 1);
+            $extra->addExtraField('show_reduc', 'Afficher la réduction sur le sous-total', 'int', 0, 10, $element_type, 0, 0, '', unserialize('a:1:{s:7:"options";a:1:{s:0:"";N;}}'), 0, '', 0, 1);
+        }
 		
         return $this->_init($sql, $options);
     }

--- a/langs/fr_FR/subtotal.lang
+++ b/langs/fr_FR/subtotal.lang
@@ -77,3 +77,5 @@ showExtrafields=Editer les attributs complémentaires
 hideExtrafields=Masquer les attributs complémentaires
 AmountBeforeTaxesSubjectToVATX%=Montant HT soumis à %s (%s %%)
 MoveTitleBlock=Déplacer le bloc titre complet
+ShowTotalHTOnSubtotalBlock=Afficher le Total HT sur la ligne de sous-total
+ShowReducOnSubtotalBlock=Afficher la réduction sur la ligne de sous-total

--- a/lib/subtotal.lib.php
+++ b/lib/subtotal.lib.php
@@ -130,6 +130,8 @@ function _updateSubtotalLine(&$object, &$line)
 	$label = GETPOST('line-title');
 	$description = ($line->qty>90) ? '' : GETPOST('line-description');
 	$pagebreak = (int) GETPOST('line-pagebreak');
+    $showTotalHT = (int) GETPOST('line-showTotalHT');
+    $showReduc = (int) GETPOST('line-showReduc');
 
 	$level = GETPOST('subtotal_level', 'int');
 	if (!empty($level))
@@ -137,6 +139,8 @@ function _updateSubtotalLine(&$object, &$line)
 		if ($line->qty > 90) $line->qty = 100 - $level; // Si on edit une ligne sous-total
 		else $line->qty = $level;
 	}
+    $line->array_options['options_show_total_ht'] = $showTotalHT;
+    $line->array_options['options_show_reduc'] = $showReduc;
 	
 	$res = TSubtotal::doUpdateLine($object, $line->id, $description, 0, $line->qty, 0, '', '', 0, 9, 0, 0, 'HT', $pagebreak, 0, 1, null, 0, $label, TSubtotal::$module_number, $line->array_options);
 


### PR DESCRIPTION
Sur l'édition d'un titre :
- Réorganisations des confs
- Ajout de 2 nouvelles config permettant d'afficher le Total HT sans les réductions ainsi que d'afficher la réduction dans la ligne de sous-total

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_subtotal/124)
<!-- Reviewable:end -->
