### PR TITLE
Fix wrong colspan when module affmarges enabled and margins hidden

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -2053,9 +2053,7 @@ class ActionsSubtotal
 				</script>
 				<?php
 			}
-			
 			if(empty($line->description)) $line->description = $line->desc;
-			
 			$colspan = 5;
 			if($object->element == 'facturerec' ) $colspan = 3;
 			if($object->element == 'order_supplier') (float) DOL_VERSION < 7.0 ? $colspan = 3 : $colspan = 6;
@@ -2065,12 +2063,12 @@ class ActionsSubtotal
 				$colspan++; // Colonne PU Devise
 			}
 			if($object->element == 'commande' && $object->statut < 3 && !empty($conf->shippableorder->enabled)) $colspan++;
-			if(!empty($conf->margin->enabled)) $colspan++;
-			if(!empty($conf->global->DISPLAY_MARGIN_RATES)) $colspan++;
-			if(!empty($conf->global->DISPLAY_MARK_RATES)) $colspan++;
+			if(!empty($conf->margin->enabled) && false !== $_SESSION['marginsdisplayed']) $colspan++;
+			if(!empty($conf->global->DISPLAY_MARGIN_RATES) && false !== $_SESSION['marginsdisplayed']) $colspan++;
+			if(!empty($conf->global->DISPLAY_MARK_RATES) && false !== $_SESSION['marginsdisplayed']) $colspan++;
 			if($object->element == 'facture' && !empty($conf->global->INVOICE_USE_SITUATION) && $object->type == Facture::TYPE_SITUATION) $colspan++;
 			if(!empty($conf->global->PRODUCT_USE_UNITS)) $colspan++;
-					
+
 			/* Titre */
 			//var_dump($line);
             

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -2063,9 +2063,11 @@ class ActionsSubtotal
 				$colspan++; // Colonne PU Devise
 			}
 			if($object->element == 'commande' && $object->statut < 3 && !empty($conf->shippableorder->enabled)) $colspan++;
-			if(!empty($conf->margin->enabled) && false !== $_SESSION['marginsdisplayed']) $colspan++;
-			if(!empty($conf->global->DISPLAY_MARGIN_RATES) && false !== $_SESSION['marginsdisplayed']) $colspan++;
-			if(!empty($conf->global->DISPLAY_MARK_RATES) && false !== $_SESSION['marginsdisplayed']) $colspan++;
+
+			$margins_hidden_by_module = empty($conf->affmarges->enabled) ? false : !($_SESSION['marginsdisplayed']);
+			if(!empty($conf->margin->enabled) && !$margins_hidden_by_module) $colspan++;
+			if(!empty($conf->global->DISPLAY_MARGIN_RATES) && !$margins_hidden_by_module) $colspan++;
+			if(!empty($conf->global->DISPLAY_MARK_RATES) && !$margins_hidden_by_module) $colspan++;
 			if($object->element == 'facture' && !empty($conf->global->INVOICE_USE_SITUATION) && $object->type == Facture::TYPE_SITUATION) $colspan++;
 			if(!empty($conf->global->PRODUCT_USE_UNITS)) $colspan++;
 


### PR DESCRIPTION
The module `affmarges` uses a session variable to determine whether to hide margin-related columns in proposals and orders even when the `margins` module is configured to display them.

When `affmarges` hides those columns, `subtotal`, as it stands, doesn’t take this into account and increases the col span as if they were shown, causing a visual mismatch between subtotal lines and other lines.