### PR TITLE
FIX: formattage des non compris

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -2093,7 +2093,7 @@ class ActionsSubtotal
 			<script type="text/javascript">
 				$(function() {
 					var subtotal_TSubNc = <?php echo json_encode($TSubNc); ?>;
-					$("#tablelines tbody > tr").each(function(i, item) {
+					$("#tablelines tr").each(function(i, item) {
 						if ($(item).children('.subtotal_nc').length == 0)
 						{
 							var id = $(item).attr('id');
@@ -2115,7 +2115,7 @@ class ActionsSubtotal
 						}
 					});
 					
-					$('#tablelines tbody tr.liste_titre:first .subtotal_nc').html(<?php echo json_encode($form->textwithtooltip($langs->trans('subtotal_nc_title'), $langs->trans('subtotal_nc_title_help'))); ?>);
+					$('#tablelines tr.liste_titre:first .subtotal_nc').html(<?php echo json_encode($form->textwithtooltip($langs->trans('subtotal_nc_title'), $langs->trans('subtotal_nc_title_help'))); ?>);
 					
 					function callAjaxUpdateLineNC(set, lineid, subtotal_nc)
 					{

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -2098,7 +2098,7 @@ class ActionsSubtotal
 						{
 							var id = $(item).attr('id');
 							
-							if ((typeof id != 'undefined' && id.indexOf('row-') >= 0) || $(item).hasClass('liste_titre'))
+							if ((typeof id != 'undefined' && id.indexOf('row-') == 0) || $(item).hasClass('liste_titre'))
 							{
 								$(item).children('td:last-child').before('<td class="subtotal_nc"></td>');
 								


### PR DESCRIPTION
- Pas d'entête de colonne "NC" parce qu'on itérait sur les `<tr>`s à l'intérieur de `<tbody>`s. Or, les entêtes sont désormais à l'intérieur de `<thead>`s
- Le test insérant la checkbox pour les non-compris était `true` pour les lignes d'extrafields (`#extrarow-...`)

Ce correctif met en valeur un bug standard Dolibarr qui crée un décalage sur les lignes d'extrafields, je vais le PR-iser

Testé en 8.0 et en 10.0