### PR TITLE
FIX 3.0 - line index replaced by line rank in method parameter

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1,38 +1,38 @@
 <?php
 class ActionsSubtotal
 {
-	
+
 	function __construct($db)
 	{
 		global $langs;
-		
+
 		$this->db = $db;
 		$langs->load('subtotal@subtotal');
-		
+
 		$this->allow_move_block_lines = true;
 	}
-	
+
 	function printFieldListSelect($parameters, &$object, &$action, $hookmanager) {
-		
+
 		global $type_element, $where;
-		
+
 		$contexts = explode(':',$parameters['context']);
-		
+
 		if(in_array('consumptionthirdparty',$contexts) && in_array($type_element, array('propal', 'order', 'invoice', 'supplier_order', 'supplier_invoice', 'supplier_proposal'))) {
 			$mod_num = TSubtotal::$module_number;
-			
+
 			// Not a title (can't use TSubtotal class methods in sql)
 			$where.= ' AND (d.special_code != '.$mod_num.' OR d.product_type != 9 OR d.qty > 9)';
 			// Not a subtotal (can't use TSubtotal class methods in sql)
 			$where.= ' AND (d.special_code != '.$mod_num.' OR d.product_type != 9 OR d.qty < 90)';
 			// Not a free line text (can't use TSubtotal class methods in sql)
 			$where.= ' AND (d.special_code != '.$mod_num.' OR d.product_type != 9 OR d.qty != 50)';
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	function createDictionaryFieldlist($parameters, &$object, &$action, $hookmanager)
 	{
 		global $conf;
@@ -47,11 +47,11 @@ class ActionsSubtotal
 				$resql = $this->db->query($sql);
 				if ($resql && ($obj = $this->db->fetch_object($resql))) $value = $obj->content;
 			}
-			
+
 			?>
 			<script type="text/javascript">
 				$(function() {
-					
+
 					<?php if ((float) DOL_VERSION >= 6.0) { ?>
 							if ($('input[name=content]').length > 0)
 							{
@@ -61,7 +61,7 @@ class ActionsSubtotal
 									if (i == $('input[name=content]').length) value = <?php echo json_encode($value); ?>;
 									$(item).replaceWith($('<textarea name="content">'+value+'</textarea>'));
 								});
-								
+
 								<?php if (!empty($conf->fckeditor->enabled) && !empty($conf->global->FCKEDITOR_ENABLE_DETAILS)) { ?>
 								$('textarea[name=content]').each(function(i, item) {
 									CKEDITOR.replace(item, {
@@ -92,7 +92,7 @@ class ActionsSubtotal
 			<?php
 		}
 	}
-	
+
 	/** Overloading the doActions function : replacing the parent's function with the one below
 	 * @param      $parameters  array           meta datas of the hook (context, etc...)
 	 * @param      $object      CommonObject    the object you want to process (an invoice if you are in invoice module, a propale in propale's module, etc...)
@@ -100,19 +100,19 @@ class ActionsSubtotal
 	 * @param      $hookmanager HookManager     current hook manager
 	 * @return     void
 	 */
-    
+
     var $module_number = 104777;
-    
-    function formObjectOptions($parameters, &$object, &$action, $hookmanager) 
+
+    function formObjectOptions($parameters, &$object, &$action, $hookmanager)
     {
       	global $langs,$db,$user, $conf;
-		
+
 		$langs->load('subtotal@subtotal');
-		
+
 		$contexts = explode(':',$parameters['context']);
-		
+
 		if(in_array('ordercard',$contexts) || in_array('ordersuppliercard',$contexts) || in_array('propalcard',$contexts) || in_array('supplier_proposalcard',$contexts) || in_array('invoicecard',$contexts) || in_array('invoicesuppliercard',$contexts) || in_array('invoicereccard',$contexts) || in_array('expeditioncard',$contexts)) {
-			
+
 			$createRight = $user->rights->{$object->element}->creer;
 			if($object->element == 'facturerec' )
 			{
@@ -129,17 +129,17 @@ class ActionsSubtotal
 			{
 				$createRight = true; // No rights management for shipments
 			}
-			
+
 			if ($object->statut == 0  && $createRight) {
-			
+
 
 				if($object->element=='facture')$idvar = 'facid';
 				else $idvar='id';
-				
+
 				if(in_array($action, array('add_title_line', 'add_total_line', 'add_subtitle_line', 'add_subtotal_line', 'add_free_text')) )
 				{
 					$level = GETPOST('level', 'int'); //New avec SUBTOTAL_USE_NEW_FORMAT
-					
+
 					if($action=='add_title_line') {
 						$title = GETPOST('title');
 						if(empty($title)) $title = $langs->trans('title');
@@ -174,9 +174,9 @@ class ActionsSubtotal
 						$qty = $level ? 100-$level : 99;
 					}
 					dol_include_once('/subtotal/class/subtotal.class.php');
-					
+
 					if (!empty($conf->global->SUBTOTAL_AUTO_ADD_SUBTOTAL_ON_ADDING_NEW_TITLE) && $qty < 10) TSubtotal::addSubtotalMissing($object, $qty);
-					
+
 	    			TSubtotal::addSubTotalLine($object, $title, $qty);
 				}
 				else if($action==='ask_deleteallline') {
@@ -184,9 +184,9 @@ class ActionsSubtotal
 
 						$lineid = GETPOST('lineid','integer');
 						$TIdForGroup = TSubtotal::getLinesFromTitleId($object, $lineid, true);
-					
+
 						$nbLines = count($TIdForGroup);
-					
+
 						$formconfirm=$form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id.'&lineid='.$lineid, $langs->trans('deleteWithAllLines'), $langs->trans('ConfirmDeleteAllThisLines',$nbLines), 'confirm_delete_all_lines','',0,1);
 						print $formconfirm;
 				}
@@ -196,7 +196,7 @@ class ActionsSubtotal
 					$this->showSelectTitleToAdd($object);
 				}
 
-				
+
 				if($object->element != 'shipping' && $action!='editline') {
 					// New format is for 3.8
 					$this->printNewFormat($object, $conf, $langs, $idvar);
@@ -213,12 +213,12 @@ class ActionsSubtotal
 				});
 			</script>
 			<?php
-			
+
 		}
 
 		return 0;
 	}
-     
+
 	function printNewFormat(&$object, &$conf, &$langs, $idvar)
 	{
 		if (empty($conf->global->SUBTOTAL_ALLOW_ADD_BLOCK)) return false;
@@ -227,7 +227,7 @@ class ActionsSubtotal
 		 	<script type="text/javascript">
 				$(document).ready(function() {
 					$('div.fiche div.tabsAction').append('<br />');
-					
+
 					$('div.fiche div.tabsAction').append('<div class="inline-block divButAction"><a id="add_title_line" rel="add_title_line" href="javascript:;" class="butAction"><?php echo  $langs->trans('AddTitle' )?></a></div>');
 					$('div.fiche div.tabsAction').append('<div class="inline-block divButAction"><a id="add_total_line" rel="add_total_line" href="javascript:;" class="butAction"><?php echo  $langs->trans('AddSubTotal')?></a></div>');
 					$('div.fiche div.tabsAction').append('<div class="inline-block divButAction"><a id="add_free_text" rel="add_free_text" href="javascript:;" class="butAction"><?php echo  $langs->trans('AddFreeText')?></a></div>');
@@ -238,18 +238,18 @@ class ActionsSubtotal
 				             CKEDITOR.instances[instance].updateElement();
 				         }
 				    }
-					
+
 					function promptSubTotal(action, titleDialog, label, url_to, url_ajax, params, use_textarea, show_free_text, show_under_title) {
 					     $( "#dialog-prompt-subtotal" ).remove();
-						 
+
 						 var dialog_html = '<div id="dialog-prompt-subtotal" '+(action == 'addSubtotal' ? 'class="center"' : '')+' >';
-						 
+
 						 if (typeof show_under_title != 'undefined' && show_under_title)
 						 {
 							 var selectUnderTitle = <?php echo json_encode(getHtmlSelectTitle($object, true)); ?>;
 							 dialog_html += selectUnderTitle + '<br /><br />';
 						 }
-						
+
 						if (action == 'addTitle' || action == 'addFreeTxt')
 						{
 							if (typeof show_free_text != 'undefined' && show_free_text)
@@ -257,15 +257,15 @@ class ActionsSubtotal
 							   var selectFreeText = <?php echo json_encode(getHtmlSelectFreeText()); ?>;
 							   dialog_html += selectFreeText + ' <?php echo $langs->transnoentities('subtotalFreeTextOrDesc'); ?><br />';
 							}
-						 
+
 							if (typeof use_textarea != 'undefined' && use_textarea) dialog_html += '<textarea id="sub-total-title" rows="<?php echo ROWS_8; ?>" cols="80" placeholder="'+label+'"></textarea>';
 							else dialog_html += '<input id="sub-total-title" size="30" value="" placeholder="'+label+'" />';
 						}
-						 
+
 						if (action == 'addTitle' || action == 'addSubtotal')
 						{
 							if (action == 'addSubtotal') dialog_html += '<input id="sub-total-title" size="30" value="" placeholder="'+label+'" />';
-							
+
 							dialog_html += "&nbsp;<select name='subtotal_line_level'>";
 							for (var i=1;i<10;i++)
 							{
@@ -273,15 +273,15 @@ class ActionsSubtotal
 							}
 							dialog_html += "</select>";
 						}
-						 
+
 						 dialog_html += '</div>';
-					    
+
 						$('body').append(dialog_html);
 
-						<?php 
+						<?php
 						$editorTool = empty($conf->global->FCKEDITOR_EDITORNAME)?'ckeditor':$conf->global->FCKEDITOR_EDITORNAME;
 						$editorConf = empty($conf->global->FCKEDITOR_ENABLE_DETAILS)?false:$conf->global->FCKEDITOR_ENABLE_DETAILS;
-						if($editorConf && in_array($editorTool,array('textarea','ckeditor'))){ 
+						if($editorConf && in_array($editorTool,array('textarea','ckeditor'))){
 						?>
 						if (action == 'addTitle' || action == 'addFreeTxt')
 						{
@@ -291,7 +291,7 @@ class ActionsSubtotal
 							}
 						}
 						<?php } ?>
-						
+
 					     $( "#dialog-prompt-subtotal" ).dialog({
 	                        resizable: false,
 							height: 'auto',
@@ -305,7 +305,7 @@ class ActionsSubtotal
 									params.under_title = $(this).find('select[name=under_title]').val();
 									params.free_text = $(this).find('select[name=free_text]').val();
 									params.level = $(this).find('select[name=subtotal_line_level]').val();
-									
+
 									$.ajax({
 										url: url_ajax
 										,type: 'POST'
@@ -313,7 +313,7 @@ class ActionsSubtotal
 									}).done(function() {
 										document.location.href=url_to;
 									});
-									
+
                                     $( this ).dialog( "close" );
 	                            },
 	                            "<?php echo $langs->trans('Cancel') ?>": function() {
@@ -322,8 +322,8 @@ class ActionsSubtotal
 	                        }
 	                     });
 					}
-					
-					$('a[rel=add_title_line]').click(function() 
+
+					$('a[rel=add_title_line]').click(function()
 					{
 						promptSubTotal('addTitle'
 							 , "<?php echo $langs->trans('YourTitleLabel') ?>"
@@ -333,7 +333,7 @@ class ActionsSubtotal
 							 , {<?php echo $idvar; ?>: <?php echo (int) $object->id; ?>, action:'add_title_line'}
 						);
 					});
-					
+
 					$('a[rel=add_total_line]').click(function()
 					{
 						promptSubTotal('addSubtotal'
@@ -345,8 +345,8 @@ class ActionsSubtotal
 							/*,false,false, <?php echo !empty($conf->global->SUBTOTAL_ALLOW_ADD_LINE_UNDER_TITLE) ? 'true' : 'false'; ?>*/
 						);
 					});
-					
-					$('a[rel=add_free_text]').click(function() 
+
+					$('a[rel=add_free_text]').click(function()
 					{
 						promptSubTotal('addFreeTxt'
 							, "<?php echo $langs->transnoentitiesnoconv('YourTextLabel') ?>"
@@ -362,40 +362,40 @@ class ActionsSubtotal
 				});
 		 	</script>
 		 <?php
-	}	 
-	 
+	}
+
 	function showSelectTitleToAdd(&$object)
 	{
 		global $langs;
-		
+
 		dol_include_once('/subtotal/class/subtotal.class.php');
 		dol_include_once('/subtotal/lib/subtotal.lib.php');
 		$TTitle = TSubtotal::getAllTitleFromDocument($object);
-		
+
 		?>
 		<script type="text/javascript">
 			$(function() {
 				var add_button = $("#addline");
-				
+
 				if (add_button.length > 0)
 				{
 					add_button.closest('tr').prev('tr.liste_titre').children('td:last').addClass('center').text("<?php echo $langs->trans('subtotal_title_to_add_under_title'); ?>");
 					var select_title = $(<?php echo json_encode(getHtmlSelectTitle($object)); ?>);
-					
+
 					add_button.before(select_title);
 				}
 			});
 		</script>
 		<?php
 	}
-	
-	
+
+
 	function formBuilddocOptions($parameters, &$object) {
-	/* Réponse besoin client */		
-			
+	/* Réponse besoin client */
+
 		global $conf, $langs, $bc;
-			
-		$action = GETPOST('action');	
+
+		$action = GETPOST('action');
 		$TContext = explode(':',$parameters['context']);
 		if (
 				in_array('invoicecard',$TContext)
@@ -405,12 +405,12 @@ class ActionsSubtotal
 		        || in_array('ordersuppliercard',$TContext)
 				|| in_array('invoicereccard',$TContext)
 			)
-	        {	
+	        {
 	            $hideInnerLines	= isset( $_SESSION['subtotal_hideInnerLines_'.$parameters['modulepart']][$object->id] ) ?  $_SESSION['subtotal_hideInnerLines_'.$parameters['modulepart']][$object->id] : 0;
 	            $hidedetails	= isset( $_SESSION['subtotal_hidedetails_'.$parameters['modulepart']][$object->id] ) ?  $_SESSION['subtotal_hidedetails_'.$parameters['modulepart']][$object->id] : 0;
 				$hidepricesDefaultConf = !empty($conf->global->SUBTOTAL_HIDE_PRICE_DEFAULT_CHECKED)?$conf->global->SUBTOTAL_HIDE_PRICE_DEFAULT_CHECKED:0;
 				$hideprices= isset( $_SESSION['subtotal_hideprices_'.$parameters['modulepart']][$object->id] ) ?  $_SESSION['subtotal_hideprices_'.$parameters['modulepart']][$object->id] : $hidepricesDefaultConf;
-				
+
 				$var=false;
 		     	$out.= '<tr '.$bc[$var].'>
 		     			<td colspan="4" align="right">
@@ -418,7 +418,7 @@ class ActionsSubtotal
 		     				<input type="checkbox" onclick="if($(this).is(\':checked\')) { $(\'#hidedetails\').prop(\'checked\', \'checked\')  }" id="hideInnerLines" name="hideInnerLines" value="1" '.(( $hideInnerLines ) ? 'checked="checked"' : '' ).' />
 		     			</td>
 		     			</tr>';
-				
+
 		     	$var=!$var;
 		     	$out.= '<tr '.$bc[$var].'>
 		     			<td colspan="4" align="right">
@@ -426,7 +426,7 @@ class ActionsSubtotal
 		     				<input type="checkbox" id="hidedetails" name="hidedetails" value="1" '.(( $hidedetails ) ? 'checked="checked"' : '' ).' />
 		     			</td>
 		     			</tr>';
-		     	
+
 		     	$var=!$var;
 		     	$out.= '<tr '.$bc[$var].'>
 		     			<td colspan="4" align="right">
@@ -434,10 +434,10 @@ class ActionsSubtotal
 		     				<input type="checkbox" id="hideprices" name="hideprices" value="1" '.(( $hideprices ) ? 'checked="checked"' : '' ).' />
 		     			</td>
 		     			</tr>';
-		     	
-		     	
-				 
-				if ( 
+
+
+
+				if (
 					(in_array('propalcard',$TContext) && !empty($conf->global->SUBTOTAL_PROPAL_ADD_RECAP))
 					|| (in_array('ordercard',$TContext) && !empty($conf->global->SUBTOTAL_COMMANDE_ADD_RECAP))
 				    || (in_array('ordersuppliercard',$TContext) && !empty($conf->global->SUBTOTAL_COMMANDE_ADD_RECAP))
@@ -455,55 +455,55 @@ class ActionsSubtotal
 							</td>
 						</tr>';
 				}
-				
-				
-				$this->resprints = $out;	
+
+
+				$this->resprints = $out;
 			}
-			
-		
+
+
         return 1;
-	} 
-	 
-    function formEditProductOptions($parameters, &$object, &$action, $hookmanager) 
+	}
+
+    function formEditProductOptions($parameters, &$object, &$action, $hookmanager)
     {
-		
+
     	if (in_array('invoicecard',explode(':',$parameters['context'])))
         {
-        	
+
         }
-		
+
         return 0;
     }
-	
+
 	function ODTSubstitutionLine(&$parameters, &$object, $action, $hookmanager) {
 		global $conf;
-		
+
 		if($action === 'builddoc') {
-			
+
 			$line = &$parameters['line'];
 			$object = &$parameters['object'];
 			$substitutionarray = &$parameters['substitutionarray'];
-			
+
             $substitutionarray['line_not_modsubtotal'] = true;
             $substitutionarray['line_modsubtotal'] = false;
             $substitutionarray['line_modsubtotal_total'] = false;
             $substitutionarray['line_modsubtotal_title'] = false;
 
 			if($line->product_type == 9 && $line->special_code == $this->module_number) {
-				$substitutionarray['line_modsubtotal'] = 1;	
+				$substitutionarray['line_modsubtotal'] = 1;
                 $substitutionarray['line_not_modsubtotal'] = false;
-				
+
 				$substitutionarray['line_price_ht']
-					 = $substitutionarray['line_price_vat'] 
+					 = $substitutionarray['line_price_vat']
 					 = $substitutionarray['line_price_ttc']
 					 = $substitutionarray['line_vatrate']
 					 = $substitutionarray['line_qty']
-					 = $substitutionarray['line_up'] 
+					 = $substitutionarray['line_up']
 					 = '';
-				
+
 				if($line->qty>90) {
 					$substitutionarray['line_modsubtotal_total'] = true;
-					
+
 					//list($total, $total_tva, $total_ttc, $TTotal_tva) = $this->getTotalLineFromObject($object, $line, '', 1);
                     $TInfo = $this->getTotalLineFromObject($object, $line, '', 1);
 
@@ -513,20 +513,20 @@ class ActionsSubtotal
 				} else {
 					$substitutionarray['line_modsubtotal_title'] = true;
 				}
-				
-				
-			}	
+
+
+			}
 			else{
 				$substitutionarray['line_not_modsubtotal'] = true;
 				$substitutionarray['line_modsubtotal'] = 0;
 			}
-			
+
 		}
-		
+
 	}
-	
+
 	function createFrom($parameters, &$object, $action, $hookmanager) {
-	
+
 		if (
 				in_array('invoicecard',explode(':',$parameters['context']))
 		        || in_array('invoicesuppliercard',explode(':',$parameters['context']))
@@ -536,54 +536,54 @@ class ActionsSubtotal
 		        || in_array('ordersuppliercard',explode(':',$parameters['context']))
 				|| in_array('invoicereccard',explode(':',$parameters['context']))
 		) {
-			
+
 			global $db;
-			
+
 			$objFrom = $parameters['objFrom'];
-			
+
 			foreach($objFrom->lines as $k=> &$lineOld) {
-				
+
 					if($lineOld->product_type == 9 && $lineOld->info_bits > 0 ) {
-							
+
 							$line = & $object->lines[$k];
-				
-							$idLine = (int) ($line->id ? $line->id : $line->rowid); 
-				
+
+							$idLine = (int) ($line->id ? $line->id : $line->rowid);
+
 							$db->query("UPDATE ".MAIN_DB_PREFIX.$line->table_element."
 							SET info_bits=".(int)$lineOld->info_bits."
 							WHERE rowid = ".$idLine."
 							");
-						
+
 					}
-				
-				
+
+
 			}
-			
-			
+
+
 		}
-		
+
 	}
-	
+
 	function doActions($parameters, &$object, $action, $hookmanager)
 	{
 		global $db, $conf, $langs,$user;
-		
+
 		dol_include_once('/subtotal/class/subtotal.class.php');
 		dol_include_once('/subtotal/lib/subtotal.lib.php');
 		require_once DOL_DOCUMENT_ROOT . '/core/class/extrafields.class.php';
-		
+
 		$showBlockExtrafields = GETPOST('showBlockExtrafields');
-		
+
 		if($object->element=='facture') $idvar = 'facid';
 		else $idvar = 'id';
-			
+
 		if ($action == 'updateligne' || $action == 'updateline')
 		{
 			$found = false;
 			$lineid = GETPOST('lineid', 'int');
 			foreach ($object->lines as &$line)
 			{
-				
+
 				if ($line->id == $lineid && TSubtotal::isModSubtotalLine($line))
 				{
 					$found = true;
@@ -594,12 +594,12 @@ class ActionsSubtotal
 					}
 					_updateSubtotalLine($object, $line);
 					_updateSubtotalBloc($object, $line);
-					
+
 					TSubtotal::generateDoc($object);
 					break;
 				}
 			}
-			
+
 			if ($found)
 			{
 				header('Location: '.$_SERVER['PHP_SELF'].'?'.$idvar.'='.$object->id);
@@ -607,7 +607,7 @@ class ActionsSubtotal
 			}
 		}
 		else if($action === 'builddoc') {
-			
+
 			if (
 				in_array('invoicecard',explode(':',$parameters['context']))
 				|| in_array('propalcard',explode(':',$parameters['context']))
@@ -616,9 +616,9 @@ class ActionsSubtotal
 			    || in_array('invoicesuppliercard',explode(':',$parameters['context']))
 			    || in_array('supplier_proposalcard',explode(':',$parameters['context']))
 			)
-	        {								
+	        {
 				if(in_array('invoicecard',explode(':',$parameters['context']))) {
-					$sessname = 'subtotal_hideInnerLines_facture';	
+					$sessname = 'subtotal_hideInnerLines_facture';
 					$sessname2 = 'subtotal_hidedetails_facture';
 					$sessname3 = 'subtotal_hideprices_facture';
 				}
@@ -629,7 +629,7 @@ class ActionsSubtotal
 				}
 				elseif(in_array('propalcard',explode(':',$parameters['context']))) {
 					$sessname = 'subtotal_hideInnerLines_propal';
-					$sessname2 = 'subtotal_hidedetails_propal';	
+					$sessname2 = 'subtotal_hidedetails_propal';
 					$sessname3 = 'subtotal_hideprices_propal';
 				}
 				elseif(in_array('supplier_proposalcard',explode(':',$parameters['context']))) {
@@ -639,7 +639,7 @@ class ActionsSubtotal
 				}
 				elseif(in_array('ordercard',explode(':',$parameters['context']))) {
 					$sessname = 'subtotal_hideInnerLines_commande';
-					$sessname2 = 'subtotal_hidedetails_commande';	
+					$sessname2 = 'subtotal_hidedetails_commande';
 					$sessname3 = 'subtotal_hideprices_commande';
 				}
 				elseif(in_array('ordersuppliercard',explode(':',$parameters['context']))) {
@@ -652,39 +652,39 @@ class ActionsSubtotal
 					$sessname2 = 'subtotal_hidedetails_unknown';
 					$sessname3 = 'subtotal_hideprices_unknown';
 				}
-					
+
 				global $hideprices;
-				
+
 				$hideInnerLines = (int)GETPOST('hideInnerLines');
 				if(empty($_SESSION[$sessname]) || !is_array($_SESSION[$sessname][$object->id]) ) $_SESSION[$sessname] = array(); // prevent old system
-				$_SESSION[$sessname][$object->id] = $hideInnerLines;		
+				$_SESSION[$sessname][$object->id] = $hideInnerLines;
 
 				$hidedetails= (int)GETPOST('hidedetails');
 				if(empty($_SESSION[$sessname2]) || !is_array($_SESSION[$sessname2][$object->id]) ) $_SESSION[$sessname2] = array(); // prevent old system
 				$_SESSION[$sessname2][$object->id] = $hidedetails;
-				
+
 				$hideprices= (int)GETPOST('hideprices');
 				if(empty($_SESSION[$sessname3]) || !is_array($_SESSION[$sessname3][$object->id]) ) $_SESSION[$sessname3] = array(); // prevent old system
 				$_SESSION[$sessname3][$object->id] = $hideprices;
-				
+
 				foreach($object->lines as &$line) {
 					if ($line->product_type == 9 && $line->special_code == $this->module_number) {
-					    
+
                         if($line->qty>=90) {
                             $line->modsubtotal_total = 1;
                         }
                         else{
                             $line->modsubtotal_title = 1;
                         }
-                        
+
 						$line->total_ht = $this->getTotalLineFromObject($object, $line, '');
 					}
 	        	}
 	        }
-			
+
 		}
 		else if($action === 'confirm_delete_all_lines' && GETPOST('confirm')=='yes') {
-			
+
 			$Tab = TSubtotal::getLinesFromTitleId($object, GETPOST('lineid'), true);
 			foreach($Tab as $line) {
 				$idLine = $line->id;
@@ -710,7 +710,7 @@ class ActionsSubtotal
 				/**
 				 * @var $object Commande
 				 */
-				else if($object->element=='commande') 
+				else if($object->element=='commande')
 				{
 					if ((float) DOL_VERSION >= 5.0) $object->deleteline($user, $idLine);
 					else $object->deleteline($idLine);
@@ -731,31 +731,31 @@ class ActionsSubtotal
 				 */
 				else if($object->element=='shipping') $object->deleteline($user, $idLine);
 			}
-			
+
 			header('location:?id='.$object->id);
 			exit;
-			
+
 		}
 		else if ($action == 'duplicate')
 		{
 			$lineid = GETPOST('lineid', 'int');
 			$nbDuplicate = TSubtotal::duplicateLines($object, $lineid, true);
-			
+
 			if ($nbDuplicate > 0) setEventMessage($langs->trans('subtotal_duplicate_success', $nbDuplicate));
 			elseif ($nbDuplicate == 0) setEventMessage($langs->trans('subtotal_duplicate_lineid_not_found'), 'warnings');
 			else setEventMessage($langs->trans('subtotal_duplicate_error'), 'errors');
-			
+
 			header('Location: ?id='.$object->id);
 			exit;
 		}
-		
+
 		return 0;
 	}
-	
+
 	function formAddObjectLine ($parameters, &$object, &$action, $hookmanager) {
 		return 0;
 	}
-	
+
 	function changeRoundingMode($parameters, &$object, &$action, $hookmanager)
 	{
 		global $conf;
@@ -769,7 +769,7 @@ class ActionsSubtotal
 				$obj = new FactureLigne($object->db);
 			if (!empty($parameters['fk_element']))
 			{
-				
+
 				if($obj->fetch($parameters['fk_element'])){
 					$obj->id= $obj->rowid;
 					if (empty($obj->array_options))
@@ -786,37 +786,37 @@ class ActionsSubtotal
 	function getArrayOfLineForAGroup(&$object, $lineid) {
 		$rang = $line->rang;
 		$qty_line = $line->qty;
-		
+
 		$qty_line = 0;
-		
+
 		$found = false;
 
 		$Tab= array();
-		
+
 		foreach($object->lines as $l) {
-		
+
 		    $lid = (!empty($l->rowid) ? $l->rowid : $l->id);
 			if($lid == $lineid) {
 
 				$found = true;
 				$qty_line = $l->qty;
 			}
-			
+
 			if($found) {
-				
+
 			    $Tab[] = (!empty($l->rowid) ? $l->rowid : $l->id);
-				
+
 				if($l->special_code==$this->module_number && (($l->qty==99 && $qty_line==1) || ($l->qty==98 && $qty_line==2))   ) {
 					break; // end of story
 				}
 			}
-			
-			
+
+
 		}
-		
-		
+
+
 		return $Tab;
-		
+
 	}
 
 	function getTotalLineFromObject(&$object, &$line, $use_level=false, $return_all=0) {
@@ -833,13 +833,13 @@ class ActionsSubtotal
 		$total_tva = 0;
 		$total_ttc = 0;
 		$TTotal_tva = array();
-		
+
 		$sign=1;
 		if (isset($object->type) && $object->type == 2 && ! empty($conf->global->INVOICE_POSITIVE_CREDIT_NOTE)) $sign=-1;
-		
+
 		if (GETPOST('action') == 'builddoc') $builddoc = true;
 		else $builddoc = false;
-		
+
 		dol_include_once('/subtotal/class/subtotal.class.php');
 
 		$TLineReverse = array_reverse($object->lines);
@@ -909,14 +909,14 @@ class ActionsSubtotal
 			$posy = $subtotal_last_title_posy;
 			$subtotal_last_title_posy = null;
 		}
-		
+
 		$hidePriceOnSubtotalLines = (int) GETPOST('hide_price_on_subtotal_lines');
 
 		if($object->element == 'shipping' || $object->element == 'delivery')
 		{
 			$hidePriceOnSubtotalLines = 1;
 		}
-		
+
 		$set_pagebreak_margin = false;
 		if(method_exists('Closure','bind')) {
 			$pageBreakOriginalValue = $pdf->AcceptPageBreak();
@@ -924,39 +924,39 @@ class ActionsSubtotal
 		    		return $pdf->bMargin ;
 			};
 			$sweetsThief = Closure::bind($sweetsThief, null, $pdf);
-	
+
 			$bMargin  = $sweetsThief($pdf);
-	
+
 			$pdf->SetAutoPageBreak( false );
 
-			$set_pagebreak_margin = true;			
+			$set_pagebreak_margin = true;
 		}
-		
-			
+
+
 		if($line->qty==99)
 			$pdf->SetFillColor(220,220,220);
 		elseif ($line->qty==98)
 			$pdf->SetFillColor(230,230,230);
 		else
 			$pdf->SetFillColor(240,240,240);
-		
+
 		$style = 'B';
 		if (!empty($conf->global->SUBTOTAL_SUBTOTAL_STYLE)) $style = $conf->global->SUBTOTAL_SUBTOTAL_STYLE;
-		
+
 		$pdf->SetFont('', $style, 9);
-		
+
 		$pdf->writeHTMLCell($w, $h, $posx, $posy, $label, 0, 1, false, true, 'R',true);
 //		var_dump($bMargin);
 		$pageAfter = $pdf->getPage();
-		
+
 		//Print background
 		$cell_height = $pdf->getStringHeight($w, $label);
 		$pdf->SetXY($posx, $posy);
 		$pdf->MultiCell($pdf->page_largeur - $pdf->marge_droite, $cell_height, '', 0, '', 1);
-		
+
 		if (!$hidePriceOnSubtotalLines) {
 			$total_to_print = price($line->total);
-			
+
 			if (!empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS))
 			{
 				$TTitle = TSubtotal::getAllTitleFromLine($line);
@@ -969,12 +969,12 @@ class ActionsSubtotal
 					}
 				}
 			}
-			
-			
-			
-			
+
+
+
+
 			if($total_to_print !== '') {
-				
+
 				if (GETPOST('hideInnerLines'))
 				{
 					// Dans le cas des lignes cachés, le calcul est déjà fait dans la méthode beforePDFCreation et les lignes de sous-totaux sont déjà renseignés
@@ -987,7 +987,7 @@ class ActionsSubtotal
 				else
 				{
 					//					list($total, $total_tva, $total_ttc, $TTotal_tva) = $this->getTotalLineFromObject($object, $line, '', 1);
-					
+
 					$TInfo = $this->getTotalLineFromObject($object, $line, '', 1);
 					$TTotal_tva = $TInfo[3];
 					$total_to_print = price($TInfo[0]);
@@ -1006,11 +1006,11 @@ class ActionsSubtotal
 		else{
 			if($set_pagebreak_margin) $pdf->SetAutoPageBreak( $pageBreakOriginalValue , $bMargin);
 		}
-		
+
 		$posy = $posy + $cell_height;
-		$pdf->SetXY($posx, $posy); 
-			
-		
+		$pdf->SetXY($posx, $posy);
+
+
 	}
 
 	/**
@@ -1025,22 +1025,22 @@ class ActionsSubtotal
 	 * @param $h            float               height
 	 */
 	function pdf_add_title(&$pdf,&$object, &$line, $label, $description,$posx, $posy, $w, $h) {
-		
+
 		global $db,$conf,$subtotal_last_title_posy;
-		
+
 		$subtotal_last_title_posy = $posy;
 		$pdf->SetXY ($posx, $posy);
-		
+
 		$hideInnerLines = (int)GETPOST('hideInnerLines');
-		
-		
- 
+
+
+
 		$style = ($line->qty==1) ? 'BU' : 'BUI';
 		if (!empty($conf->global->SUBTOTAL_TITLE_STYLE)) $style = $conf->global->SUBTOTAL_TITLE_STYLE;
-		
+
 		if($hideInnerLines) {
 			if($line->qty==1)$pdf->SetFont('', $style, 9);
-			else 
+			else
 			{
 				if (!empty($conf->global->SUBTOTAL_STYLE_TITRES_SI_LIGNES_CACHEES)) $style = $conf->global->SUBTOTAL_STYLE_TITRES_SI_LIGNES_CACHEES;
 				$pdf->SetFont('', $style, 9);
@@ -1050,34 +1050,34 @@ class ActionsSubtotal
 
 			if($line->qty==1)$pdf->SetFont('', $style, 9); //TODO if super utile
 			else $pdf->SetFont('', $style, 9);
-			
+
 		}
-		
+
 		if ($label === strip_tags($label) && $label === dol_html_entity_decode($label, ENT_QUOTES)) $pdf->MultiCell($w, $h, $label, 0, 'L'); // Pas de HTML dans la chaine
 		else $pdf->writeHTMLCell($w, $h, $posx, $posy, $label, 0, 1, false, true, 'J',true); // et maintenant avec du HTML
-		
+
 		if($description && !$hidedesc) {
 			$posy = $pdf->GetY();
-			
+
 			$pdf->SetFont('', '', 8);
-			
+
 			$pdf->writeHTMLCell($w, $h, $posx, $posy, $description, 0, 1, false, true, 'J',true);
 
 		}
-		
+
 	}
 
 	function pdf_writelinedesc_ref($parameters=array(), &$object, &$action='') {
 	// ultimate PDF hook O_o
-		
+
 		return $this->pdf_writelinedesc($parameters,$object,$action);
-		
+
 	}
 
 	function isModSubtotalLine(&$parameters, &$object) {
-		
+
 		if(is_array($parameters)) {
-			$i = & $parameters['i'];	
+			$i = & $parameters['i'];
 		}
 		else {
 			$i = (int)$parameters;
@@ -1091,14 +1091,14 @@ class ActionsSubtotal
 			$line = new OrderLine($object->db);
 			$line->fetch($object->lines[$i]->fk_origin_line);
 		}
-		
+
 
 		if($line->special_code == $this->module_number && $line->product_type == 9) {
 			return true;
 		}
-		
+
 		return false;
-		
+
 	}
 
 	function pdf_getlineqty($parameters=array(), &$object, &$action='') {
@@ -1106,14 +1106,14 @@ class ActionsSubtotal
 
 		if($this->isModSubtotalLine($parameters,$object) ){
 			$this->resprints = ' ';
-			
+
 			if((float)DOL_VERSION<=3.6) {
 				return '';
 			}
 			else if((float)DOL_VERSION>=3.8) {
 				return 1;
 			}
-			
+
 		}
 		elseif(!empty($hideprices)) {
 			$this->resprints = $object->lines[$parameters['i']]->qty;
@@ -1128,12 +1128,12 @@ class ActionsSubtotal
 				$this->resprints = $object->lines[$parameters['i']]->qty;
 			}
 		}
-		
+
 		if(is_array($parameters)) $i = & $parameters['i'];
 		else $i = (int)$parameters;
 
 		if (empty($object->lines[$i])) return 0; // hideInnerLines => override $object->lines et Dolibarr ne nous permet pas de mettre à jour la variable qui conditionne la boucle sur les lignes (PR faite pour 6.0)
-		
+
 		if(empty($object->lines[$i]->array_options)) $object->lines[$i]->fetch_optionals();
 
 		if (!empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS) && (!empty($object->lines[$i]->array_options['options_subtotal_nc']) || TSubtotal::hasNcTitle($object->lines[$i])) )
@@ -1144,33 +1144,33 @@ class ActionsSubtotal
 				return 1;
 			}
 		}
-		
+
 		return 0;
 	}
-	
+
 	function pdf_getlinetotalexcltax($parameters=array(), &$object, &$action='') {
 	    global $conf, $hideprices, $hookmanager;
-		
+
 		if(is_array($parameters)) $i = & $parameters['i'];
 		else $i = (int)$parameters;
-			
+
 		if($this->isModSubtotalLine($parameters,$object) ){
-			
+
 			$this->resprints = ' ';
-			
+
 			if((float)DOL_VERSION<=3.6) {
 				return '';
 			}
 			else if((float)DOL_VERSION>=3.8) {
 				return 1;
 			}
-			
+
 		}
 		elseif (!empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS))
 		{
 			if (!in_array(__FUNCTION__, explode(',', $conf->global->SUBTOTAL_TFIELD_TO_KEEP_WITH_NC)))
 			{
-				if (!empty($object->lines[$i]->array_options['options_subtotal_nc'])) 
+				if (!empty($object->lines[$i]->array_options['options_subtotal_nc']))
 				{
 					$this->resprints = ' ';
 					return 1;
@@ -1190,18 +1190,18 @@ class ActionsSubtotal
 		if ((int)GETPOST('hideInnerLines') && !empty($conf->global->SUBTOTAL_REPLACE_WITH_VAT_IF_HIDE_INNERLINES)){
 		    $this->resprints = price($object->lines[$i]->total_ht);
 		}
-		
+
 		// Si la gestion C/NC est active et que je suis sur un ligne dont l'extrafield est coché
-		if ( 
-			!empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS) && 
-			(!empty($object->lines[$i]->array_options['options_subtotal_nc']) || TSubtotal::hasNcTitle($object->lines[$i])) 
+		if (
+			!empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS) &&
+			(!empty($object->lines[$i]->array_options['options_subtotal_nc']) || TSubtotal::hasNcTitle($object->lines[$i]))
 		)
 		{
 			// alors je dois vérifier si la méthode fait partie de la conf qui l'exclue
 			if (!in_array(__FUNCTION__, explode(',', $conf->global->SUBTOTAL_TFIELD_TO_KEEP_WITH_NC)))
 			{
 				$this->resprints = ' ';
-				
+
 				// currentcontext à modifier celon l'appel
 				$params = array('parameters' => $parameters, 'currentmethod' => 'pdf_getlinetotalexcltax', 'currentcontext'=>'subtotal_hide_nc', 'i' => $i);
 				return $this->callHook($object, $hookmanager, $action, $params); // return 1 (qui est la valeur par défaut) OU -1 si erreur OU overrideReturn (contient -1 ou 0 ou 1)
@@ -1211,21 +1211,21 @@ class ActionsSubtotal
 		else if (!empty($hideprices))
 		{
 			// Check if a title exist for this line && if the title have subtotal
-			$lineTitle = TSubtotal::getParentTitleOfLine($object, $i);
-			if(TSubtotal::getParentTitleOfLine($object, $i) && TSubtotal::titleHasTotalLine($object, $lineTitle, true))
+			$lineTitle = TSubtotal::getParentTitleOfLine($object, $object->lines[$i]->rang);
+			if ($lineTitle && TSubtotal::titleHasTotalLine($object, $lineTitle, true))
 			{
 
 				$this->resprints = ' ';
-				
+
 				// currentcontext à modifier celon l'appel
 				$params = array('parameters' => $parameters, 'currentmethod' => 'pdf_getlinetotalexcltax', 'currentcontext'=>'subtotal_hideprices', 'i' => $i);
 				return $this->callHook($object, $hookmanager, $action, $params); // return 1 (qui est la valeur par défaut) OU -1 si erreur OU overrideReturn (contient -1 ou 0 ou 1)
 			}
 		}
-        
+
 		return 0;
 	}
-	
+
 	/**
 	 * Remplace le retour de la méthode qui l'appelle par un standard 1 ou autre chose celon le hook
 	 * @return int 1, 0, -1
@@ -1256,14 +1256,14 @@ class ActionsSubtotal
 
 		return $defaultReturn;
 	}
-	
+
 	function pdf_getlinetotalwithtax($parameters=array(), &$object, &$action='') {
 		global $conf;
-		
+
 		if($this->isModSubtotalLine($parameters,$object) ){
-			
+
 			$this->resprints = ' ';
-		
+
 			if((float)DOL_VERSION<=3.6) {
 				return '';
 			}
@@ -1271,39 +1271,10 @@ class ActionsSubtotal
 				return 1;
 			}
 		}
-		
+
 		if(is_array($parameters)) $i = & $parameters['i'];
 		else $i = (int)$parameters;
-		
-		if (!empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS) && (!empty($object->lines[$i]->array_options['options_subtotal_nc']) || TSubtotal::hasNcTitle($object->lines[$i])) ) 
-		{
-			if (!in_array(__FUNCTION__, explode(',', $conf->global->SUBTOTAL_TFIELD_TO_KEEP_WITH_NC)))
-			{
-				$this->resprints = ' ';
-				return 1;
-			}
-		}
-		
-		return 0;
-	}
-	
-	function pdf_getlineunit($parameters=array(), &$object, &$action='') {
-		global $conf;
-		
-		if($this->isModSubtotalLine($parameters,$object) ){
-			$this->resprints = ' ';
-		
-			if((float)DOL_VERSION<=3.6) {
-				return '';
-			}
-			else if((float)DOL_VERSION>=3.8) {
-				return 1;
-			}
-		}
-		
-		if(is_array($parameters)) $i = & $parameters['i'];
-		else $i = (int)$parameters;
-			
+
 		if (!empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS) && (!empty($object->lines[$i]->array_options['options_subtotal_nc']) || TSubtotal::hasNcTitle($object->lines[$i])) )
 		{
 			if (!in_array(__FUNCTION__, explode(',', $conf->global->SUBTOTAL_TFIELD_TO_KEEP_WITH_NC)))
@@ -1312,10 +1283,39 @@ class ActionsSubtotal
 				return 1;
 			}
 		}
-		
+
 		return 0;
 	}
-	
+
+	function pdf_getlineunit($parameters=array(), &$object, &$action='') {
+		global $conf;
+
+		if($this->isModSubtotalLine($parameters,$object) ){
+			$this->resprints = ' ';
+
+			if((float)DOL_VERSION<=3.6) {
+				return '';
+			}
+			else if((float)DOL_VERSION>=3.8) {
+				return 1;
+			}
+		}
+
+		if(is_array($parameters)) $i = & $parameters['i'];
+		else $i = (int)$parameters;
+
+		if (!empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS) && (!empty($object->lines[$i]->array_options['options_subtotal_nc']) || TSubtotal::hasNcTitle($object->lines[$i])) )
+		{
+			if (!in_array(__FUNCTION__, explode(',', $conf->global->SUBTOTAL_TFIELD_TO_KEEP_WITH_NC)))
+			{
+				$this->resprints = ' ';
+				return 1;
+			}
+		}
+
+		return 0;
+	}
+
 	function pdf_getlineupexcltax($parameters=array(), &$object, &$action='') {
 	    global $conf,$hideprices,$hookmanager;
 
@@ -1329,7 +1329,7 @@ class ActionsSubtotal
 
             // On récupère les montants du bloc pour les afficher dans la ligne de sous-total
             if(TSubtotal::isSubtotal($line)) {
-                $parentTitle = TSubtotal::getParentTitleOfLine($object, $i);
+                $parentTitle = TSubtotal::getParentTitleOfLine($object, $line->rang);
 
                 if(is_object($parentTitle) && empty($parentTitle->array_options)) $parentTitle->fetch_optionals();
                 if(! empty($parentTitle->array_options['options_show_total_ht'])) {
@@ -1337,7 +1337,7 @@ class ActionsSubtotal
                     $this->resprints = price($TTotal['total_unit_subprice']);
                 }
             }
-		
+
 			if((float)DOL_VERSION<=3.6) {
 				return '';
 			}
@@ -1345,7 +1345,7 @@ class ActionsSubtotal
 				return 1;
 			}
 		}
-		
+
 		// Si la gestion C/NC est active et que je suis sur un ligne dont l'extrafield est coché
 		if (
 		!empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS) &&
@@ -1356,33 +1356,33 @@ class ActionsSubtotal
 		    if (!in_array(__FUNCTION__, explode(',', $conf->global->SUBTOTAL_TFIELD_TO_KEEP_WITH_NC)))
 		    {
 		        $this->resprints = ' ';
-		        
+
 		        // currentcontext à modifier celon l'appel
 		        $params = array('parameters' => $parameters, 'currentmethod' => 'pdf_getlineupexcltax', 'currentcontext'=>'subtotal_hide_nc', 'i' => $i);
 		        return $this->callHook($object, $hookmanager, $action, $params); // return 1 (qui est la valeur par défaut) OU -1 si erreur OU overrideReturn (contient -1 ou 0 ou 1)
-		        
+
 		    }
 		}
 		// Cache le prix pour les lignes standards dolibarr qui sont dans un ensemble
 		else if (!empty($hideprices))
 		{
-		    
+
 		    // Check if a title exist for this line && if the title have subtotal
-		    $lineTitle = TSubtotal::getParentTitleOfLine($object, $i);
-		    if(TSubtotal::getParentTitleOfLine($object, $i) && TSubtotal::titleHasTotalLine($object, $lineTitle, true))
+		    $lineTitle = TSubtotal::getParentTitleOfLine($object, $object->lines[$i]->rang);
+		    if ($lineTitle && TSubtotal::titleHasTotalLine($object, $lineTitle, true))
 		    {
-		        
+
 		        $this->resprints = ' ';
-		        
+
 		        // currentcontext à modifier celon l'appel
 		        $params = array('parameters' => $parameters, 'currentmethod' => 'pdf_getlineupexcltax', 'currentcontext'=>'subtotal_hideprices', 'i' => $i);
 		        return $this->callHook($object, $hookmanager, $action, $params); // return 1 (qui est la valeur par défaut) OU -1 si erreur OU overrideReturn (contient -1 ou 0 ou 1)
 		    }
 		}
-		
+
 		return 0;
 	}
-	
+
 	function pdf_getlineremisepercent($parameters=array(), &$object, &$action='') {
 	    global $conf,$hideprices,$hookmanager;
 
@@ -1394,9 +1394,9 @@ class ActionsSubtotal
 
             $line = $object->lines[$i];
 
-            // Affichage de la remise 
+            // Affichage de la remise
             if(TSubtotal::isSubtotal($line)) {
-                $parentTitle = TSubtotal::getParentTitleOfLine($object, $i);
+                $parentTitle = TSubtotal::getParentTitleOfLine($object, $line->rang);
 
                 if(empty($parentTitle->array_options)) $parentTitle->fetch_optionals();
                 if(! empty($parentTitle->array_options['options_show_reduc'])) {
@@ -1404,7 +1404,7 @@ class ActionsSubtotal
                     $this->resprints = price((1-$TTotal['total_ht'] / $TTotal['total_subprice'])*100, 0, '', 1, 2, 2).'%';
                 }
             }
-		
+
 			if((float)DOL_VERSION<=3.6) {
 				return '';
 			}
@@ -1422,13 +1422,13 @@ class ActionsSubtotal
 		            return 1;
 		        }
 		    }
-		
+
 		return 0;
 	}
-	
+
 	function pdf_getlineupwithtax($parameters=array(), &$object, &$action='') {
 		global $conf,$hideprices;
-		
+
 		if($this->isModSubtotalLine($parameters,$object) ){
 			$this->resprints = ' ';
 			if((float)DOL_VERSION<=3.6) {
@@ -1438,10 +1438,10 @@ class ActionsSubtotal
 				return 1;
 			}
 		}
-		
+
 		if(is_array($parameters)) $i = & $parameters['i'];
 		else $i = (int)$parameters;
-			
+
 		if (!empty($hideprices)
 				|| (!empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS) && (!empty($object->lines[$i]->array_options['options_subtotal_nc']) || TSubtotal::hasNcTitle($object->lines[$i])) )
 		)
@@ -1452,16 +1452,16 @@ class ActionsSubtotal
 				return 1;
 			}
 		}
-		
+
 		return 0;
 	}
-	
+
 	function pdf_getlinevatrate($parameters=array(), &$object, &$action='') {
 	    global $conf,$hideprices,$hookmanager;
-	    
+
 		if($this->isModSubtotalLine($parameters,$object) ){
 			$this->resprints = ' ';
-			
+
 			if((float)DOL_VERSION<=3.6) {
 				return '';
 			}
@@ -1469,10 +1469,10 @@ class ActionsSubtotal
 				return 1;
 			}
 		}
-		
+
 		if(is_array($parameters)) $i = & $parameters['i'];
 		else $i = (int)$parameters;
-		
+
 		if (empty($object->lines[$i])) return 0; // hideInnerLines => override $object->lines et Dolibarr ne nous permet pas de mettre à jour la variable qui conditionne la boucle sur les lignes (PR faite pour 6.0)
 
 		$object->lines[$i]->fetch_optionals();
@@ -1486,7 +1486,7 @@ class ActionsSubtotal
 		    if (!in_array(__FUNCTION__, explode(',', $conf->global->SUBTOTAL_TFIELD_TO_KEEP_WITH_NC)))
 		    {
 		        $this->resprints = ' ';
-		        
+
 		        // currentcontext à modifier celon l'appel
 		        $params = array('parameters' => $parameters, 'currentmethod' => 'pdf_getlinevatrate', 'currentcontext'=>'subtotal_hide_nc', 'i' => $i);
 		        return $this->callHook($object, $hookmanager, $action, $params); // return 1 (qui est la valeur par défaut) OU -1 si erreur OU overrideReturn (contient -1 ou 0 ou 1)
@@ -1495,26 +1495,26 @@ class ActionsSubtotal
 		// Cache le prix pour les lignes standards dolibarr qui sont dans un ensemble
 		else if (!empty($hideprices))
 		{
-		    
+
 		    // Check if a title exist for this line && if the title have subtotal
-		    $lineTitle = TSubtotal::getParentTitleOfLine($object, $i);
-		    if(TSubtotal::getParentTitleOfLine($object, $i) && TSubtotal::titleHasTotalLine($object, $lineTitle, true))
+		    $lineTitle = TSubtotal::getParentTitleOfLine($object, $object->lines[$i]->rang);
+		    if ($lineTitle && TSubtotal::titleHasTotalLine($object, $lineTitle, true))
 		    {
-		        
+
 		        $this->resprints = ' ';
-		        
+
 		        // currentcontext à modifier celon l'appel
 		        $params = array('parameters' => $parameters, 'currentmethod' => 'pdf_getlinevatrate', 'currentcontext'=>'subtotal_hideprices', 'i' => $i);
 		        return $this->callHook($object, $hookmanager, $action, $params); // return 1 (qui est la valeur par défaut) OU -1 si erreur OU overrideReturn (contient -1 ou 0 ou 1)
 		    }
 		}
-		
+
 		return 0;
 	}
-		
+
 	function pdf_getlineprogress($parameters=array(), &$object, &$action) {
 		global $conf;
-		
+
 		if($this->isModSubtotalLine($parameters,$object) ){
 			$this->resprints = ' ';
 			if((float)DOL_VERSION<=3.6) {
@@ -1524,10 +1524,10 @@ class ActionsSubtotal
 				return 1;
 			}
 		}
-		
+
 		if(is_array($parameters)) $i = & $parameters['i'];
 		else $i = (int)$parameters;
-			
+
 		if (!empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS) && (!empty($object->lines[$i]->array_options['options_subtotal_nc']) || TSubtotal::hasNcTitle($object->lines[$i])) )
 		{
 			if (!in_array(__FUNCTION__, explode(',', $conf->global->SUBTOTAL_TFIELD_TO_KEEP_WITH_NC)))
@@ -1536,43 +1536,43 @@ class ActionsSubtotal
 				return 1;
 			}
 		}
-		
+
 		return 0;
 	}
-	
+
 	function add_numerotation(&$object) {
 		global $conf;
-		
+
 		if(!empty($conf->global->SUBTOTAL_USE_NUMEROTATION)) {
-		
+
 			$TLevelTitre = array();
 			$prevlevel = 0;
-		
-			foreach($object->lines as $k=>&$line) 
+
+			foreach($object->lines as $k=>&$line)
 			{
 				if ($line->id > 0 && $this->isModSubtotalLine($k, $object) && $line->qty <= 10)
 				{
 					$TLineTitle[] = &$line;
 				}
 			}
-			
+
 			if (!empty($TLineTitle)) $TTitleNumeroted = $this->formatNumerotation($TLineTitle);
 		}
-		
+
 	}
 
 	// TODO ne gère pas encore la numération des lignes "Totaux"
 	private function formatNumerotation(&$TLineTitle, $line_reference='', $level=1, $prefix_num=0)
 	{
 		$TTitle = array();
-		
+
 		$i=1;
 		$j=0;
 		foreach ($TLineTitle as $k => &$line)
 		{
 			if (!empty($line_reference) && $line->rang <= $line_reference->rang) continue;
 			if (!empty($line_reference) && $line->qty <= $line_reference->qty) break;
-			
+
 			if ($line->qty == $level)
 			{
 				$TTitle[$j]['numerotation'] = ($prefix_num == 0) ? $i : $prefix_num.'.'.$i;
@@ -1582,17 +1582,17 @@ class ActionsSubtotal
 					$line->label = !empty($line->desc) ? $line->desc : $line->description;
 					$line->desc = $line->description = '';
 				}
-				
+
 				$line->label = $TTitle[$j]['numerotation'].' '.$line->label;
 				$TTitle[$j]['line'] = &$line;
-				
+
 				$deep_level = $line->qty;
 				do {
 					$deep_level++;
 					$TTitle[$j]['children'] = $this->formatNumerotation($TLineTitle, $line, $deep_level, $TTitle[$j]['numerotation']);
 				} while (empty($TTitle[$j]['children']) && $deep_level <= 10); // Exemple si un bloc Titre lvl 1 contient pas de sous lvl 2 mais directement un sous lvl 5
 				// Rappel on peux avoir jusqu'a 10 niveau de titre
-				
+
 				$i++;
 				$j++;
 			}
@@ -1600,18 +1600,18 @@ class ActionsSubtotal
 
 		return $TTitle;
 	}
-	
+
 	function setDocTVA(&$pdf, &$object) {
-		
+
 		$hidedetails = (int)GETPOST('hidedetails');
-		
+
 		if(empty($hidedetails)) return false;
-		
+
 		// TODO can't add VAT to document without lines... :-/
-		
+
 		return true;
 	}
-	
+
 	function beforePDFCreation($parameters=array(), &$object, &$action)
 	{
 		/**
@@ -1625,14 +1625,14 @@ class ActionsSubtotal
 		foreach($parameters as $key=>$value) {
 			${$key} = $value;
 		}
-		
+
 		$this->setDocTVA($pdf, $object);
-		
-		$this->add_numerotation($object);	
-		
+
+		$this->add_numerotation($object);
+
         foreach($object->lines as $k => &$l) {
             if(TSubtotal::isSubtotal($l)) {
-                $parentTitle = TSubtotal::getParentTitleOfLine($object, $k);
+                $parentTitle = TSubtotal::getParentTitleOfLine($object, $l->rang);
                 if(is_object($parentTitle) && empty($parentTitle->array_options)) $parentTitle->fetch_optionals();
                 if(! empty($parentTitle->id) && ! empty($parentTitle->array_options['options_show_reduc'])) {
                     $l->remise_percent = 100;    // Affichage de la réduction sur la ligne de sous-total
@@ -1654,27 +1654,27 @@ class ActionsSubtotal
 		if ($hideInnerLines) { // si c une ligne de titre
 	    	$fk_parent_line=0;
 			$TLines =array();
-		
+
 			$original_count=count($object->lines);
 		    $TTvas = array(); // tableau de tva
-		    
-			foreach($object->lines as $k=>&$line) 
+
+			foreach($object->lines as $k=>&$line)
 			{
-			    
-				if($line->product_type==9 && $line->rowid>0) 
+
+				if($line->product_type==9 && $line->rowid>0)
 				{
 					$fk_parent_line = $line->rowid;
-					
+
 					// Fix tk7201 - si on cache le détail, la TVA est renseigné au niveau du sous-total, l'erreur c'est s'il y a plusieurs sous-totaux pour les même lignes, ça va faire la somme
-					if(TSubtotal::isSubtotal($line)) 
+					if(TSubtotal::isSubtotal($line))
 					{
 						/*$total = $this->getTotalLineFromObject($object, $line, '');
-						
+
 						$line->total_ht = $total;
 						$line->total = $total;
 						*/
 						//list($total, $total_tva, $total_ttc, $TTotal_tva) = $this->getTotalLineFromObject($object, $line, '', 1);
-						
+
 						$TInfo = $this->getTotalLineFromObject($object, $line, '', 1);
 
 						if (TSubtotal::getNiveau($line) == 1) $line->TTotal_tva = $TInfo[3];
@@ -1683,28 +1683,28 @@ class ActionsSubtotal
 						$line->total = $line->total_ht;
 						$line->total_ttc = $TInfo[2];
 
-//                        $TTitle = TSubtotal::getParentTitleOfLine($object, $k);
+//                        $TTitle = TSubtotal::getParentTitleOfLine($object, $line->rang);
 //                        $parentTitle = array_shift($TTitle);
 //                        if(! empty($parentTitle->id) && ! empty($parentTitle->array_option['options_show_total_ht'])) {
 //                            exit('la?');
 //                            $line->remise_percent = 100;    // Affichage de la réduction sur la ligne de sous-total
 //                            $line->update();
 //                        }
-					} 
+					}
 //                    if(TSub)
-						
-				} 
-			
+
+				}
+
 				if ($hideInnerLines)
 				{
 				    if(!empty($conf->global->SUBTOTAL_REPLACE_WITH_VAT_IF_HIDE_INNERLINES))
 				    {
 				        if($line->tva_tx != '0.000' && $line->product_type!=9){
-				            
+
     				        // on remplit le tableau de tva pour substituer les lignes cachées
     				        $TTvas[$line->tva_tx]['total_tva'] += $line->total_tva;
     				        $TTvas[$line->tva_tx]['total_ht'] += $line->total_ht;
-    				        $TTvas[$line->tva_tx]['total_ttc'] += $line->total_ttc; 
+    				        $TTvas[$line->tva_tx]['total_ttc'] += $line->total_ttc;
     				    }
     					if($line->product_type==9 && $line->rowid>0)
     					{
@@ -1727,38 +1727,38 @@ class ActionsSubtotal
     					            array_shift($TTvas);
     					       }
     					    }
-    					    
+
     					    // ajoute la ligne de sous-total
-    					    $TLines[] = $line; 
+    					    $TLines[] = $line;
     					}
 				    } else {
-				        
+
 				        if($line->product_type==9 && $line->rowid>0)
 				        {
 				            // ajoute la ligne de sous-total
-				            $TLines[] = $line; 
+				            $TLines[] = $line;
 				        }
 				    }
-				    
-					
+
+
 				}
 				elseif ($hidedetails)
 				{
-					$TLines[] = $line; //Cas où je cache uniquement les prix des produits	
+					$TLines[] = $line; //Cas où je cache uniquement les prix des produits
 				}
-				
+
 				if ($line->product_type != 9) { // jusqu'au prochain titre ou total
 					//$line->fk_parent_line = $fk_parent_line;
-					
+
 				}
-			
+
 				/*if($hideTotal) {
 					$line->total = 0;
 					$line->subprice= 0;
 				}*/
-				
+
 			}
-			
+
 			// cas incongru où il y aurait des produits en dessous du dernier sous-total
 			$nbtva = count($TTvas);
 			if(!empty($nbtva) && $hideInnerLines && !empty($conf->global->SUBTOTAL_REPLACE_WITH_VAT_IF_HIDE_INNERLINES))
@@ -1778,18 +1778,18 @@ class ActionsSubtotal
 			        array_shift($TTvas);
 			    }
 			}
-			
+
 			global $nblignes;
 			$nblignes=count($TLines);
 
 			$object->lines = $TLines;
-			
+
 			if($i>count($object->lines)) {
 				$this->resprints = '';
 				return 0;
 			}
 	    }
-		
+
 		return 0;
 	}
 
@@ -1803,20 +1803,20 @@ class ActionsSubtotal
 		foreach($parameters as $key=>$value) {
 			${$key} = $value;
 		}
-		
+
 		$hideInnerLines = (int)GETPOST('hideInnerLines');
 		$hidedetails = (int)GETPOST('hidedetails');
-		
-		if($this->isModSubtotalLine($parameters,$object) ){			
-		
+
+		if($this->isModSubtotalLine($parameters,$object) ){
+
 				global $hideprices;
-				
+
 				if(!empty($hideprices)) {
 					foreach($object->lines as &$line) {
-						if($line->fk_product_type!=9) $line->fk_parent_line = -1;	
+						if($line->fk_product_type!=9) $line->fk_parent_line = -1;
 					}
 				}
-			
+
 				$line = &$object->lines[$i];
 
 				if($object->element == 'delivery' && ! empty($object->commande->expeditions[$line->fk_origin_line])) unset($object->commande->expeditions[$line->fk_origin_line]);
@@ -1825,10 +1825,10 @@ class ActionsSubtotal
 					$pdf->addPage();
 					$posy = $pdf->GetY();
 				}
-				
+
 				$label = $line->label;
 				$description= !empty($line->desc) ? $outputlangs->convToOutputCharset($line->desc) : $outputlangs->convToOutputCharset($line->description);
-				
+
 				if(empty($label)) {
 					$label = $description;
 					$description='';
@@ -1836,10 +1836,10 @@ class ActionsSubtotal
 
 				if($line->qty>90) {
 					if ($conf->global->SUBTOTAL_USE_NEW_FORMAT)	$label .= ' '.$this->getTitle($object, $line);
-					
+
 					$pageBefore = $pdf->getPage();
 					$this->pdf_add_total($pdf,$object, $line, $label, $description,$posx, $posy, $w, $h);
-					$pageAfter = $pdf->getPage();	
+					$pageAfter = $pdf->getPage();
 
 					if($pageAfter>$pageBefore) {
 						//print "ST $pageAfter>$pageBefore<br>";
@@ -1870,23 +1870,23 @@ class ActionsSubtotal
 
 						$pdf->SetTextColor($grey, $grey, $grey);
 					}
-				
+
 					$posy = $pdf->GetY();
 					return 1;
-				}	
+				}
 				else if ($line->qty < 10) {
 					$pageBefore = $pdf->getPage();
 
-					$this->pdf_add_title($pdf,$object, $line, $label, $description,$posx, $posy, $w, $h); 
-					$pageAfter = $pdf->getPage();	
+					$this->pdf_add_title($pdf,$object, $line, $label, $description,$posx, $posy, $w, $h);
+					$pageAfter = $pdf->getPage();
 
-					
+
 					/*if($pageAfter>$pageBefore) {
 						print "T $pageAfter>$pageBefore<br>";
 						$pdf->rollbackTransaction(true);
 						$pdf->addPage('','', true);
 						print 'add T'.$pdf->getPage().' '.$line->rowid.' '.$pdf->GetY().' '.$posy.'<br />';
-						
+
 						$posy = $pdf->GetY();
 						$this->pdf_add_title($pdf,$object, $line, $label, $description,$posx, $posy, $w, $h);
 						$posy = $pdf->GetY();
@@ -1902,7 +1902,7 @@ class ActionsSubtotal
 					return 1;
 				}
 //	if($line->rowid==47) exit;
-			
+
 			return 0;
 		}
 		elseif (empty($object->lines[$parameters['i']]))
@@ -1912,7 +1912,7 @@ class ActionsSubtotal
 
 		/* TODO je desactive parce que je comprends pas PH Style, mais à test
 		else {
-			
+
 			if($hideInnerLines) {
 				$pdf->rollbackTransaction(true);
 			}
@@ -1920,37 +1920,37 @@ class ActionsSubtotal
 				$labelproductservice=pdf_getlinedesc($object, $i, $outputlangs, $hideref, $hidedesc, $issupplierline);
 				$pdf->writeHTMLCell($w, $h, $posx, $posy, $outputlangs->convToOutputCharset($labelproductservice), 0, 1);
 			}
-			
+
 		}*/
 
 
-		
+
 	}
 
 	/**
 	 * Permet de récupérer le titre lié au sous-total
-	 * 
+	 *
 	 * @return string
 	 */
 	function getTitle(&$object, &$currentLine)
 	{
 		$res = '';
-		
+
 		foreach ($object->lines as $line)
 		{
 			if ($line->id == $currentLine->id) break;
-			
+
 			$qty_search = 100 - $currentLine->qty;
-			
-			if ($line->product_type == 9 && $line->special_code == $this->module_number && $line->qty == $qty_search) 
+
+			if ($line->product_type == 9 && $line->special_code == $this->module_number && $line->qty == $qty_search)
 			{
 				$res = ($line->label) ? $line->label : (($line->description) ? $line->description : $line->desc);
 			}
 		}
-		
+
 		return $res;
 	}
-	
+
 	/**
 	 * @param $parameters   array
 	 * @param $object       CommonObject
@@ -1959,13 +1959,13 @@ class ActionsSubtotal
 	 * @return int
 	 */
 	function printObjectLine ($parameters, &$object, &$action, $hookmanager){
-		
+
 		global $conf,$langs,$user,$db,$bc;
-		
+
 		$num = &$parameters['num'];
 		$line = &$parameters['line'];
 		$i = &$parameters['i'];
-		
+
 		$var = &$parameters['var'];
 
 		$contexts = explode(':',$parameters['context']);
@@ -2032,7 +2032,7 @@ class ActionsSubtotal
             }
 			return 0;
 		}
-		else if (in_array('invoicecard',$contexts) || in_array('invoicesuppliercard',$contexts) || in_array('propalcard',$contexts) || in_array('supplier_proposalcard',$contexts) || in_array('ordercard',$contexts) || in_array('ordersuppliercard',$contexts) || in_array('invoicereccard',$contexts)) 
+		else if (in_array('invoicecard',$contexts) || in_array('invoicesuppliercard',$contexts) || in_array('propalcard',$contexts) || in_array('supplier_proposalcard',$contexts) || in_array('ordercard',$contexts) || in_array('ordersuppliercard',$contexts) || in_array('invoicereccard',$contexts))
         {
 
 
@@ -2079,11 +2079,11 @@ class ActionsSubtotal
 
 			/* Titre */
 			//var_dump($line);
-            
+
 			// HTML 5 data for js
             $data = $this->_getHtmlData($parameters, $object, $action, $hookmanager);
-            
-			
+
+
 			?>
 			<tr <?php echo $bc[$var]; $var=!$var; echo $data; ?> rel="subtotal" id="row-<?php echo $line->id ?>" style="<?php
 					if (!empty($conf->global->SUBTOTAL_USE_NEW_FORMAT))
@@ -2098,7 +2098,7 @@ class ActionsSubtotal
 
 						//A compléter si on veux plus de nuances de couleurs avec les niveau 4,5,6,7,8 et 9
 					}
-					else 
+					else
 					{
 						if($line->qty==99) print 'background:#ddffdd';
 						else if($line->qty==98) print 'background:#ddddff;';
@@ -2118,7 +2118,7 @@ class ActionsSubtotal
 
 						$params=array('line'=>$line);
 						$reshook=$hookmanager->executeHooks('formEditProductOptions',$params,$object,$action);
-						
+
 						echo '<div id="line_'.$line->id.'"></div>'; // Imitation Dolibarr
 						echo '<input type="hidden" value="'.$line->id.'" name="lineid">';
 						echo '<input id="product_type" type="hidden" value="'.$line->product_type.'" name="type">';
@@ -2130,7 +2130,7 @@ class ActionsSubtotal
 						{
 							$qty_displayed = $line->qty;
 							print img_picto('', 'subsubtotal@subtotal').'<span style="font-size:9px;margin-left:-3px;color:#0075DE;">'.$qty_displayed.'</span>&nbsp;&nbsp;';
-							
+
 						}
 						else if (TSubtotal::isSubtotal($line))
 						{
@@ -2141,7 +2141,7 @@ class ActionsSubtotal
 						{
 							$isFreeText = true;
 						}
-						
+
 						if ($object->element == 'order_supplier' || $object->element == 'invoice_supplier') {
 						    $line->label = !empty($line->description) ? $line->description : $line->desc;
 						    $line->description = '';
@@ -2159,9 +2159,9 @@ class ActionsSubtotal
 
 						$readonlyForSituation = '';
 						if (!empty($line->fk_prev_id) && $line->fk_prev_id != null) $readonlyForSituation = 'readonly';
-						
+
 						if (!$isFreeText) echo '<input type="text" name="line-title" id-line="'.$line->id.'" value="'.$newlabel.'" size="80" '.$readonlyForSituation.'/>&nbsp;';
-						
+
 						if (!empty($conf->global->SUBTOTAL_USE_NEW_FORMAT) && (TSubtotal::isTitle($line) || TSubtotal::isSubtotal($line)) )
 						{
 							$select = '<select name="subtotal_level">';
@@ -2175,7 +2175,7 @@ class ActionsSubtotal
 
 							echo $select;
 						}
-						
+
 
 						echo '<div class="subtotal_underline" style="margin-left:24px; line-height: 25px;">';
                         echo '<div>';
@@ -2251,55 +2251,55 @@ class ActionsSubtotal
 								}
 							}
 						}
-						
+
 					}
 					else {
 
 						 if ($conf->global->SUBTOTAL_USE_NEW_FORMAT)
 						 {
-							if(TSubtotal::isTitle($line) || TSubtotal::isSubtotal($line)) 
+							if(TSubtotal::isTitle($line) || TSubtotal::isSubtotal($line))
 							{
 								echo str_repeat('&nbsp;&nbsp;&nbsp;', $line->qty-1);
-								
+
 								if (TSubtotal::isTitle($line)) print img_picto('', 'subtotal@subtotal').'<span style="font-size:9px;margin-left:-3px;">'.$line->qty.'</span>&nbsp;&nbsp;';
 								else print img_picto('', 'subtotal2@subtotal').'<span style="font-size:9px;margin-left:-1px;">'.(100-$line->qty).'</span>&nbsp;&nbsp;';
 							}
 						 }
-						 else 
+						 else
 						 {
 							if($line->qty<=1) print img_picto('', 'subtotal@subtotal');
-							else if($line->qty==2) print img_picto('', 'subsubtotal@subtotal').'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'; 
+							else if($line->qty==2) print img_picto('', 'subsubtotal@subtotal').'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;';
 						 }
-						 
-						 
+
+
 						 // Get display styles and apply them
 						 $titleStyleItalic = strpos($conf->global->SUBTOTAL_TITLE_STYLE, 'I') === false ? '' : ' font-style: italic;';
 						 $titleStyleBold =  strpos($conf->global->SUBTOTAL_TITLE_STYLE, 'B') === false ? '' : ' font-weight:bold;';
 						 $titleStyleUnderline =  strpos($conf->global->SUBTOTAL_TITLE_STYLE, 'U') === false ? '' : ' text-decoration: underline;';
-						 
+
 						 if (empty($line->label)) {
 							if ($line->qty >= 91 && $line->qty <= 99 && $conf->global->SUBTOTAL_USE_NEW_FORMAT) print  $line->description.' '.$this->getTitle($object, $line);
 							else print  $line->description;
-						 } 
+						 }
 						 else {
 
 							if (! empty($conf->global->PRODUIT_DESC_IN_FORM) && !empty($line->description)) {
 								print '<span class="subtotal_label" style="'.$titleStyleItalic.$titleStyleBold.$titleStyleUnderline.'" >'.$line->label.'</span><br><div class="subtotal_desc">'.dol_htmlentitiesbr($line->description).'</div>';
 							}
 							else{
-								print '<span class="subtotal_label classfortooltip '.$titleStyleItalic.$titleStyleBold.$titleStyleUnderline.'" title="'.$line->description.'">'.$line->label.'</span>';    
+								print '<span class="subtotal_label classfortooltip '.$titleStyleItalic.$titleStyleBold.$titleStyleUnderline.'" title="'.$line->description.'">'.$line->label.'</span>';
 							}
 
-						 } 
+						 }
 						if($line->qty>90) print ' : ';
 						if($line->info_bits > 0) echo img_picto($langs->trans('Pagebreak'), 'pagebreak@subtotal');
 
-						 
+
 
 
 					}
 			?></td>
-					 
+
 			<?php
 				if($line->qty>90) {
 					/* Total */
@@ -2313,13 +2313,13 @@ class ActionsSubtotal
 					if (!empty($conf->multicurrency->enabled) && ((float) DOL_VERSION < 8.0 || $object->multicurrency_code != $conf->currency)) {
 						echo '<td class="linecoltotalht_currency">&nbsp;</td>';
 					}
-				}	
+				}
 			?>
-					
+
 			<td align="center" class="nowrap linecoledit">
 				<?php
 				if ($action != 'selectlines') {
-				
+
 					if($action=='editline' && GETPOST('lineid') == $line->id && TSubtotal::isModSubtotalLine($line) ) {
 						?>
 						<input id="savelinebutton" class="button" type="submit" name="save" value="<?php echo $langs->trans('Save') ?>" />
@@ -2334,7 +2334,7 @@ class ActionsSubtotal
 
 						</script>
 						<?php
-						
+
 					}
 					else{
 						if ($object->statut == 0  && $createRight && !empty($conf->global->SUBTOTAL_ALLOW_DUPLICATE_BLOCK) && $object->element !== 'invoice_supplier')
@@ -2342,18 +2342,18 @@ class ActionsSubtotal
 							if(TSubtotal::isTitle($line) && ( $line->fk_prev_id === null )) echo '<a href="'.$_SERVER['PHP_SELF'].'?'.$idvar.'='.$object->id.'&action=duplicate&lineid='.$line->id.'">'. img_picto($langs->trans('Duplicate'), 'duplicate@subtotal').'</a>';
 						}
 
-						if ($object->statut == 0  && $createRight && !empty($conf->global->SUBTOTAL_ALLOW_EDIT_BLOCK)) 
+						if ($object->statut == 0  && $createRight && !empty($conf->global->SUBTOTAL_ALLOW_EDIT_BLOCK))
 						{
 							echo '<a href="'.$_SERVER['PHP_SELF'].'?'.$idvar.'='.$object->id.'&action=editline&lineid='.$line->id.'">'.img_edit().'</a>';
-						}								
+						}
 					}
-					
+
 				}
-					
+
 				?>
 			</td>
 
-			<td align="center" class="nowrap linecoldelete">	
+			<td align="center" class="nowrap linecoldelete">
 				<?php
 
 				if ($action != 'editline' && $action != 'selectlines') {
@@ -2394,15 +2394,15 @@ class ActionsSubtotal
 					}
 				?>
 			</td>
-			
-			<?php 
+
+			<?php
 			if ($object->statut == 0  && $createRight && !empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS) && TSubtotal::isTitle($line) && $action != 'editline')
 			{
 				echo '<td class="subtotal_nc">';
 				echo '<input id="subtotal_nc-'.$line->id.'" class="subtotal_nc_chkbx" data-lineid="'.$line->id.'" type="checkbox" name="subtotal_nc" value="1" '.(!empty($line->array_options['options_subtotal_nc']) ? 'checked="checked"' : '').' />';
 				echo '</td>';
 			}
-			
+
 			if ($num > 1 && empty($conf->browser->phone)) { ?>
 			<td align="center" class="linecolmove tdlineupdown">
 			</td>
@@ -2417,20 +2417,20 @@ class ActionsSubtotal
 
 			</tr>
 			<?php
-			
-			
+
+
 			// Affichage des extrafields à la Dolibarr (car sinon non affiché sur les titres)
 			if(TSubtotal::isTitle($line) && !empty($conf->global->SUBTOTAL_ALLOW_EXTRAFIELDS_ON_TITLE)) {
-				
+
 				require_once DOL_DOCUMENT_ROOT . '/core/class/extrafields.class.php';
-				
+
 				// Extrafields
 				$extrafieldsline = new ExtraFields($db);
 				$extralabelsline = $extrafieldsline->fetch_name_optionals_label($object->table_element_line);
-				
+
 				$colspan+=3; $mode = 'view';
 				if($action === 'editline' && $line->rowid == GETPOST('lineid')) $mode = 'edit';
-				
+
 				$ex_element = $line->element;
 				$line->element = 'tr_extrafield_title '.$line->element; // Pour pouvoir manipuler ces tr
 				print $line->showOptionals($extrafieldsline, $mode, array('style'=>' style="background:#eeffee;" ','colspan'=>$colspan));
@@ -2441,14 +2441,14 @@ class ActionsSubtotal
 						break;
 					}
 				}
-				
+
 				if($mode === 'edit') {
 					?>
 					<script>
 						$(document).ready(function(){
 
 							var all_tr_extrafields = $("tr.tr_extrafield_title");
-							<?php 
+							<?php
 							// Si un extrafield est rempli alors on affiche directement les extrafields
 							if(!$isExtraSelected) {
 								echo 'all_tr_extrafields.hide();';
@@ -2460,7 +2460,7 @@ class ActionsSubtotal
 								echo 'var extra = 1;';
 							}
 							?>
-							
+
 							$("div .subtotal_underline").append(
 									'<a id="printBlocExtrafields" onclick="return false;" href="#">' + trad + '</a>'
 									+ '<input type="hidden" name="showBlockExtrafields" id="showBlockExtrafields" value="'+ extra +'" />');
@@ -2483,11 +2483,11 @@ class ActionsSubtotal
 					<?php
 				}
 				$line->element = $ex_element;
-				
+
 			}
-			
-			return 1;	
-			
+
+			return 1;
+
 		}
 		elseif(($object->element == 'commande' && in_array('ordershipmentcard', $contexts)) || (in_array('expeditioncard', $contexts) && $action == 'create'))
 		{
@@ -2622,7 +2622,7 @@ class ActionsSubtotal
 
 						//A compléter si on veux plus de nuances de couleurs avec les niveau 4,5,6,7,8 et 9
 					}
-					else 
+					else
 					{
 						if($line->qty==99) print 'background:#ddffdd';
 						else if($line->qty==98) print 'background:#ddddff;';
@@ -2742,13 +2742,13 @@ class ActionsSubtotal
 
 	}
 
-	
+
 	function addMoreActionsButtons($parameters, &$object, &$action, $hookmanager) {
 		global $conf,$langs;
-		 
+
 		if ($object->statut == 0 && !empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS) && $action != 'editline')
 		{
-		    
+
 		    if($object->element == 'invoice_supplier' || $object->element == 'order_supplier')
 		    {
 		        foreach ($object->lines as $line)
@@ -2760,13 +2760,13 @@ class ActionsSubtotal
 		            $line->fetch_optionals($line->id,$extralabels);
 		        }
 		    }
-		    
+
 			$TSubNc = array();
 			foreach ($object->lines as &$l)
 			{
 				$TSubNc[$l->id] = (int) $l->array_options['options_subtotal_nc'];
 			}
-			
+
 			$form = new Form($db);
 			?>
 			<script type="text/javascript">
@@ -2776,26 +2776,26 @@ class ActionsSubtotal
 						if ($(item).children('.subtotal_nc').length == 0)
 						{
 							var id = $(item).attr('id');
-							
+
 							if ((typeof id != 'undefined' && id.indexOf('row-') == 0) || $(item).hasClass('liste_titre'))
 							{
 								$(item).children('td:last-child').before('<td class="subtotal_nc"></td>');
-								
+
 								if ($(item).attr('rel') != 'subtotal' && typeof $(item).attr('id') != 'undefined')
 								{
 									var idSplit = $(item).attr('id').split('-');
 									$(item).children('td.subtotal_nc').append($('<input type="checkbox" id="subtotal_nc-'+idSplit[1]+'" class="subtotal_nc_chkbx" data-lineid="'+idSplit[1]+'" value="1" '+(typeof subtotal_TSubNc[idSplit[1]] != 'undefined' && subtotal_TSubNc[idSplit[1]] == 1 ? 'checked="checked"' : '')+' />'));
 								}
 							}
-							else 
+							else
 							{
 								$(item).append('<td class="subtotal_nc"></td>');
 							}
 						}
 					});
-					
+
 					$('#tablelines tr.liste_titre:first .subtotal_nc').html(<?php echo json_encode($form->textwithtooltip($langs->trans('subtotal_nc_title'), $langs->trans('subtotal_nc_title_help'))); ?>);
-					
+
 					function callAjaxUpdateLineNC(set, lineid, subtotal_nc)
 					{
 						$.ajax({
@@ -2813,29 +2813,29 @@ class ActionsSubtotal
 							window.location.href = window.location.pathname + '?id=<?php echo $object->id; ?>&page_y=' + window.pageYOffset;
 						});
 					}
-					
+
 					$(".subtotal_nc_chkbx").change(function(event) {
 						var lineid = $(this).data('lineid');
-						var subtotal_nc = 0 | $(this).is(':checked'); // Renvoi 0 ou 1 
-						
+						var subtotal_nc = 0 | $(this).is(':checked'); // Renvoi 0 ou 1
+
 						callAjaxUpdateLineNC('updateLineNC', lineid, subtotal_nc);
 					});
-					
+
 				});
 
 			</script>
 			<?php
 		}
-		
+
 		$this->_ajax_block_order_js($object);
 	}
-	
+
 	function afterPDFCreation($parameters, &$pdf, &$action, $hookmanager)
 	{
 		global $conf;
-		
+
 		$object = $parameters['object'];
-		
+
 		if ((!empty($conf->global->SUBTOTAL_PROPAL_ADD_RECAP) && $object->element == 'propal') || (!empty($conf->global->SUBTOTAL_COMMANDE_ADD_RECAP) && $object->element == 'commande') || (!empty($conf->global->SUBTOTAL_INVOICE_ADD_RECAP) && $object->element == 'facture'))
 		{
 			if (GETPOST('subtotal_add_recap')) {
@@ -2844,19 +2844,19 @@ class ActionsSubtotal
 			}
 		}
 	}
-	
+
 	// HTML 5 data for js
 	private function _getHtmlData($parameters, &$object, &$action, $hookmanager)
 	{
 		dol_include_once('/subtotal/class/subtotal.class.php');
 
 	    $line = &$parameters['line'];
-	    
+
 	    $ThtmlData['data-id']           = $line->id;
 	    $ThtmlData['data-product_type'] = $line->product_type;
 	    $ThtmlData['data-qty']          = 0; //$line->qty;
 	    $ThtmlData['data-level']        = TSubtotal::getNiveau($line);
-	    
+
 	    if(TSubtotal::isTitle($line)){
 	        $ThtmlData['data-issubtotal'] = 'title';
 	    }elseif(TSubtotal::isSubtotal($line)){
@@ -2865,12 +2865,12 @@ class ActionsSubtotal
 	    else{
 	        $ThtmlData['data-issubtotal'] = 'freetext';
 	    }
-	    
-	    
+
+
 	    // Change or add data  from hooks
 	    $parameters = array_replace($parameters , array(  'ThtmlData' => $ThtmlData )  );
-	    
-	    // hook 
+
+	    // hook
 	    $reshook = $hookmanager->executeHooks('subtotalLineHtmlData',$parameters,$object,$action); // Note that $action and $object may have been modified by hook
 	    if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 	    if ($reshook>0)
@@ -2879,10 +2879,10 @@ class ActionsSubtotal
 	    }
 
 	    return $this->implodeHtmlData($ThtmlData);
-	
+
 	}
-	
-	
+
+
 	function implodeHtmlData($ThtmlData = array())
 	{
 	    $data = '';
@@ -2892,40 +2892,40 @@ class ActionsSubtotal
 	        {
 	            $h = json_encode($h);
 	        }
-	        
+
 	        $data .= $k . '="'.dol_htmlentities($h, ENT_QUOTES).'" ';
 	    }
-	    
+
 	    return $data;
 	}
-	
+
 	function _ajax_block_order_js($object)
 	{
 	    global $conf,$tagidfortablednd,$filepath,$langs;
-	    
+
 	    /*
-	     * this part of js is base on dolibarr htdocs/core/tpl/ajaxrow.tpl.php 
+	     * this part of js is base on dolibarr htdocs/core/tpl/ajaxrow.tpl.php
 	     * for compatibility reasons we don't use tableDnD but jquery sortable
 	     */
-	    
+
 	    $id=$object->id;
 	    $nboflines=(isset($object->lines)?count($object->lines):0);
 	    $forcereloadpage=empty($conf->global->MAIN_FORCE_RELOAD_PAGE)?0:1;
-	    
+
 	    $id=$object->id;
 	    $fk_element=$object->fk_element;
 	    $table_element_line=$object->table_element_line;
 	    $nboflines=(isset($object->lines)?count($object->lines):(empty($nboflines)?0:$nboflines));
 	    $tagidfortablednd=(empty($tagidfortablednd)?'tablelines':$tagidfortablednd);
 	    $filepath=(empty($filepath)?'':$filepath);
-	    
-	    
+
+
 	    if (GETPOST('action','aZ09') != 'editline' && $nboflines > 1)
 	    {
-	        
+
 	        ?>
-		
-		
+
+
 			<script type="text/javascript">
 			$(document).ready(function(){
 
@@ -2934,7 +2934,7 @@ class ActionsSubtotal
 				var lastTitleCol = titleRow.find('td:last-child');
 				var moveBlockCol= titleRow.find('td.linecolht');
 
-				
+
 				moveBlockCol.disableSelection(); // prevent selection
 <?php if ($object->statut == 0) { ?>
 				// apply some graphical stuff
@@ -2943,7 +2943,7 @@ class ActionsSubtotal
 				moveBlockCol.css("background-position","center center");
 				moveBlockCol.css("cursor","move");
 				titleRow.attr('title', '<?php echo html_entity_decode($langs->trans('MoveTitleBlock')); ?>');
-			
+
 
  				$( "#<?php echo $tagidfortablednd; ?>" ).sortable({
 			    	  cursor: "move",
@@ -2958,17 +2958,17 @@ class ActionsSubtotal
 			    		  //console.log(ui.item);
 			    		  var colCount = ui.item.children().length;
    						  ui.placeholder.html('<td colspan="'+colCount+'">&nbsp;</td>');
-   		
+
 			    		  var TcurrentChilds = getSubtotalTitleChilds(ui.item);
 			    		  ui.item.data('childrens',TcurrentChilds); // store data
-				    		
+
 			    		  for (var key in TcurrentChilds) {
-			    			  $('#'+ TcurrentChilds[key]).addClass('noblockdrop');//'#row-'+ 
-			    			  $('#'+ TcurrentChilds[key]).fadeOut();//'#row-'+ 
+			    			  $('#'+ TcurrentChilds[key]).addClass('noblockdrop');//'#row-'+
+			    			  $('#'+ TcurrentChilds[key]).fadeOut();//'#row-'+
 			    		  }
 
 			    		  $(this).sortable("refresh");	// "refresh" of source sortable is required to make "disable" work!
-			    	      
+
 			    	    },
 				    	stop: function (event, ui) {
 							// call we element is droped
@@ -2977,12 +2977,12 @@ class ActionsSubtotal
 				    	  	var TcurrentChilds = ui.item.data('childrens'); // reload child list from data and not attr to prevent load error
 
 							for (var i =TcurrentChilds.length ; i >= 0; i--) {
-				    			  $('#'+ TcurrentChilds[i]).insertAfter(ui.item); //'#row-'+ 
-				    			  $('#'+ TcurrentChilds[i]).fadeIn(); //'#row-'+ 
+				    			  $('#'+ TcurrentChilds[i]).insertAfter(ui.item); //'#row-'+
+				    			  $('#'+ TcurrentChilds[i]).fadeIn(); //'#row-'+
 							}
 							console.log('onstop');
 							console.log(cleanSerialize($(this).sortable('serialize')));
-							
+
 							$.ajax({
 			    	            data: {
 									objet_id: <?php print $object->id; ?>,
@@ -2998,10 +2998,10 @@ class ActionsSubtotal
 			    	                console.log(data);
 			    	            },
 			    	        });
-			    	        
+
 			    	  },
 			    	  update: function (event, ui) {
-				    	  
+
 			    	        // POST to server using $.post or $.ajax
 				    	  	$('.noblockdrop').removeClass('noblockdrop');
 							//console.log('onupdate');
@@ -3017,12 +3017,12 @@ class ActionsSubtotal
 
 		    		var indexOfFirstSubtotal = -1;
 		    		var indexOfFirstTitle = -1;
-		    		
+
 		    		item.nextAll('[id^="row-"]').each(function(index){
 
 						var dataLevel = $(this).attr('data-level');
 						var dataIsSubtotal = $(this).attr('data-issubtotal');
-						
+
 						if(dataIsSubtotal != 'undefined' && dataLevel != 'undefined' )
 						{
 
@@ -3034,7 +3034,7 @@ class ActionsSubtotal
 									TcurrentChilds.push($(this).attr('id'));
 								}
 							}
-							
+
 							if(dataLevel <=  level && indexOfFirstSubtotal < 0 && indexOfFirstTitle < 0 && dataIsSubtotal == 'title' )
 							{
 								indexOfFirstTitle = index;
@@ -3054,17 +3054,17 @@ class ActionsSubtotal
 									TcurrentChilds.push($(this).attr('id'));
 								});
 							}
-							
+
 						}
 
 		    		});
 		    		return TcurrentChilds;
 				}
-				
+
 			});
 			</script>
 			<style type="text/css" >
-         
+
             tr.ui-state-highlight td{
             	border: 1px solid #dad55e;
             	background: #fffa90;
@@ -3072,11 +3072,11 @@ class ActionsSubtotal
             }
             </style>
 		<?php
-		
-		} 
-	
-		
-		
+
+		}
+
+
+
 	}
-	
+
 }

--- a/class/subtotal.class.php
+++ b/class/subtotal.class.php
@@ -332,6 +332,12 @@ class TSubtotal {
 		else return false;
 	}
 
+	/**
+	 * @param FactureLigne|PropaleLigne|OrderLine $object
+	 * @param int $rang  rank of the line in the object; The first line has rank = 1, not 0.
+	 * @param int $lvl
+	 * @return bool|FactureLigne|PropaleLigne|OrderLine
+	 */
 	public static function getParentTitleOfLine(&$object, $rang, $lvl = 0)
 	{
 		if ($rang <= 0) return false;


### PR DESCRIPTION
# Issue
On proposals, when the option “Cacher le prix des lignes des ensembles” was on, the first price of every subtotal group was not hidden on the generated PDF.

# Cause
`TSubtotal::getParentTitleOfLine` was refactored last year and its `$i` parameter (representing the array index of the line in `$object->lines`) was replaced with `$rang` (representing the line’s rank, which is usually `$i + 1` since array indices start with 0, but line ranks start with 1 in Dolibarr).
The value was thus shifted by 1.

# Fix
All calls of `TSubtotal::getParentTitleOfLine` were changed so that the parameter matches what the function expects (a rank, not an array index). The PHPDoc was also modified to highlight this potential issue.
This might fix other yet undetected issues.