### PR TITLE
FIX replace useless trigger

### DIFF
--- a/class/subtotal.class.php
+++ b/class/subtotal.class.php
@@ -450,6 +450,7 @@ class TSubtotal {
 			{
 				$object->db->begin();
 				$res = 1;
+                $object->context['subtotalDuplicateLines'] = true;
 
 				$TLineAdded = array();
 				foreach ($TLine as $line)
@@ -511,17 +512,6 @@ class TSubtotal {
 					$TLineAdded[] = $object->line;
 					// Error from addline
 					if ($res <= 0) break;
-					else
-					{
-						$object->line_from = $line;
-						// Call trigger
-						$result=$object->call_trigger('LINE_DUPLICATE',$user); // $object->line
-						if ($result < 0)
-						{
-							$object->db->rollback();
-							return -2;
-						}
-					}
 				}
 
 				if ($res > 0)

--- a/class/subtotal.class.php
+++ b/class/subtotal.class.php
@@ -520,7 +520,8 @@ class TSubtotal {
 					foreach ($TLineAdded as &$line)
 					{
 					    // ça peut paraitre non optimisé de déclancher la fonction sur toutes les lignes mais ceci est nécessaire pour réappliquer l'état exact de chaque ligne
-					    _updateLineNC($object->element, $object->id, $line->id, $line->array_options['options_subtotal_nc']);
+                        //En gros ça met à jour le sous total
+					   if(!empty($line->array_options['options_subtotal_nc'])) _updateLineNC($object->element, $object->id, $line->id, $line->array_options['options_subtotal_nc']);
 					}
 					return count($TLineAdded);
 				}


### PR DESCRIPTION
Après avoir vérifié sur le blackmirror, ce trigger n'est utilisé que dans la module nomenclature, suite à mon fix, ce trigger est amené à disparaitre car nous avons déjà le trigger lineobject_insert, et le context est bien transmis à la ligne
à valider avec la PR sur nomenclature https://github.com/ATM-Consulting/dolibarr_module_nomenclature/pull/121