### PR TITLE
Fix 3.0 numerotation auto des totaux également

### DIFF
--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -63,7 +63,7 @@ class modSubtotal extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Module permettant l'ajout de sous-totaux et sous-totaux intermédiaires et le déplacement d'une ligne aisée de l'un dans l'autre";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '3.4.1';
+        $this->version = '3.4.2';
         // Key used in llx_const table to save module status enabled/disabled
         // (where MYMODULE is value of property name of module in uppercase)
         $this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);


### PR DESCRIPTION
TK11022

Dans le wiki, il est marqué que la numérotation automatique des lignes fonctionne sur les titres et sous-totaux. cf : http://wiki.atm-consulting.fr/index.php/Sous-total/Documentation_utilisateur#Activer_la_num.C3.A9rotation_automatique_sur_le_PDF

Or, ce n'était pas le cas...