### PR TITLE
FIX: in recent Dolibarr versions, the default check for GETPOST is "alphanohtml" instead of "none"

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -149,7 +149,7 @@ class ActionsSubtotal
 						$qty = $level<1 ? 1 : $level ;
 					}
 					else if($action=='add_free_text') {
-						$title = GETPOST('title');
+						$title = GETPOST('title', 'restricthtml');
 
 						if (empty($title)) {
 							$free_text = GETPOST('free_text', 'int');


### PR DESCRIPTION
cf. [f4f3efec62060d224f2be2254cbebcf25f8d60b4](https://github.com/Dolibarr/dolibarr/commit/f4f3efec62060d224f2be2254cbebcf25f8d60b4).

As a consequence, any markup from CKEditor when adding free text lines with subtotal is removed.