### PR TITLE
FIX: in recent Dolibarr versions, the default check for GETPOST is "alphanohtml"

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -149,7 +149,7 @@ class ActionsSubtotal
 						$qty = $level<1 ? 1 : $level ;
 					}
 					else if($action=='add_free_text') {
-						$title = GETPOST('title');
+						$title = GETPOST('title', 'restricthtml');
 
 						if (empty($title)) {
 							$free_text = GETPOST('free_text', 'int');


### PR DESCRIPTION
cf. PR https://github.com/ATM-Consulting/dolibarr_module_subtotal/pull/166