### PR TITLE
FIX : GETPOST check parameter missing (none)

### DIFF
--- a/admin/subtotal_setup.php
+++ b/admin/subtotal_setup.php
@@ -46,19 +46,19 @@ if (! $user->admin) {
 $action = GETPOST('action', 'alpha');
 
 if($action=='save') {
-	
+
 	foreach($_REQUEST['TDivers'] as $name=>$param) {
-		
+
 		dolibarr_set_const($db, $name, $param,'chaine', 0, '', $conf->entity);
-		
+
 	}
-	
+
 }
 
 if (preg_match('/set_(.*)/',$action,$reg))
 {
 	$code=$reg[1];
-	$value = GETPOST($code);
+	$value = GETPOST($code, 'none');
 	if (in_array($code, array(
 		'SUBTOTAL_TFIELD_TO_KEEP_WITH_NC'
 		, 'SUBTOTAL_LIST_OF_EXTRAFIELDS_PROPALDET'
@@ -69,7 +69,7 @@ if (preg_match('/set_(.*)/',$action,$reg))
 	if (dolibarr_set_const($db, $code, $value, 'chaine', 0, '', $conf->entity) > 0)
 	{
 		if ($code == 'SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS' && $value == 1) _createExtraComprisNonCompris();
-		
+
 		header("Location: ".$_SERVER["PHP_SELF"]);
 		exit;
 	}
@@ -107,9 +107,9 @@ showParameters();
 
 function showParameters() {
 	global $db,$conf,$langs,$bc;
-	
+
 	$html=new Form($db);
-	
+
 	$var=false;
 	print '<table class="noborder" width="100%">';
 	print '<tr class="liste_titre">';
@@ -117,7 +117,7 @@ function showParameters() {
 	print '<td align="center" width="20">&nbsp;</td>';
 	print '<td align="center" width="100">'.$langs->trans("Value").'</td>'."\n";
 	print '</tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("SUBTOTAL_USE_NEW_FORMAT").'</td>';
@@ -125,7 +125,7 @@ function showParameters() {
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('SUBTOTAL_USE_NEW_FORMAT');
 	print '</td></tr>';
-	
+
 	if((float)DOL_VERSION>=3.8)
 	{
 		$var=!$var;
@@ -134,9 +134,9 @@ function showParameters() {
 		print '<td align="center" width="20">&nbsp;</td>';
 		print '<td align="center" width="300">';
 		print ajax_constantonoff('SUBTOTAL_USE_NUMEROTATION');
-		print '</td></tr>';	
+		print '</td></tr>';
 	}
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("SUBTOTAL_ALLOW_ADD_BLOCK").'</td>';
@@ -144,7 +144,7 @@ function showParameters() {
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('SUBTOTAL_ALLOW_ADD_BLOCK');
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("SUBTOTAL_ALLOW_EDIT_BLOCK").'</td>';
@@ -152,7 +152,7 @@ function showParameters() {
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('SUBTOTAL_ALLOW_EDIT_BLOCK');
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("SUBTOTAL_ALLOW_REMOVE_BLOCK").'</td>';
@@ -160,7 +160,7 @@ function showParameters() {
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('SUBTOTAL_ALLOW_REMOVE_BLOCK');
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("SUBTOTAL_ALLOW_DUPLICATE_BLOCK").'</td>';
@@ -176,7 +176,7 @@ function showParameters() {
     print '<td align="center" width="300">';
     print ajax_constantonoff('SUBTOTAL_ALLOW_DUPLICATE_LINE');
     print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("SUBTOTAL_ALLOW_ADD_LINE_UNDER_TITLE").'</td>';
@@ -184,7 +184,7 @@ function showParameters() {
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('SUBTOTAL_ALLOW_ADD_LINE_UNDER_TITLE');
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("SUBTOTAL_ADD_LINE_UNDER_TITLE_AT_END_BLOCK").'</td>';
@@ -205,7 +205,7 @@ function showParameters() {
 	print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
 	print '</form>';
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("SUBTOTAL_TITLE_STYLE").'</td>';
@@ -218,7 +218,7 @@ function showParameters() {
 	print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
 	print '</form>';
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("SUBTOTAL_SUBTOTAL_STYLE").'</td>';
@@ -231,7 +231,7 @@ function showParameters() {
 	print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
 	print '</form>';
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("SUBTOTAL_ONE_LINE_IF_HIDE_INNERLINES", $langs->transnoentitiesnoconv('HideInnerLines')).'</td>';
@@ -239,7 +239,7 @@ function showParameters() {
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('SUBTOTAL_ONE_LINE_IF_HIDE_INNERLINES');
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("SUBTOTAL_REPLACE_WITH_VAT_IF_HIDE_INNERLINES", $langs->transnoentitiesnoconv('HideInnerLines')).'</td>';
@@ -247,7 +247,7 @@ function showParameters() {
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('SUBTOTAL_REPLACE_WITH_VAT_IF_HIDE_INNERLINES');
 	print '</td></tr>';
-	
+
 	if ((double) DOL_VERSION >= 4.0)
 	{
 		$var=!$var;
@@ -262,7 +262,7 @@ function showParameters() {
 		print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
 		print '</form>';
 		print '</td></tr>';
-		
+
 		$var=!$var;
 		print '<tr '.$bc[$var].'>';
 		print '<td>'.$langs->trans("SUBTOTAL_TFIELD_TO_KEEP_WITH_NC").'</td>';
@@ -272,10 +272,10 @@ function showParameters() {
 		print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
 		print '<input type="hidden" name="action" value="set_SUBTOTAL_TFIELD_TO_KEEP_WITH_NC">';
 		$TField = array(
-		    'pdf_getlineqty' => $langs->trans('Qty'), 
-		    'pdf_getlinevatrate' => $langs->trans('VAT'), 
-		    'pdf_getlineupexcltax' => $langs->trans('PriceUHT'), 
-		    'pdf_getlinetotalexcltax' => $langs->trans('TotalHT'), 
+		    'pdf_getlineqty' => $langs->trans('Qty'),
+		    'pdf_getlinevatrate' => $langs->trans('VAT'),
+		    'pdf_getlineupexcltax' => $langs->trans('PriceUHT'),
+		    'pdf_getlinetotalexcltax' => $langs->trans('TotalHT'),
 		    'pdf_getlineunit' => $langs->trans('Unit'),
 		    'pdf_getlineremisepercent' => $langs->trans('Discount')
 		);
@@ -284,7 +284,7 @@ function showParameters() {
 		print '</form>';
 		print '</td></tr>';
 	}
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans('SUBTOTAL_AUTO_ADD_SUBTOTAL_ON_ADDING_NEW_TITLE').'</td>';
@@ -292,7 +292,7 @@ function showParameters() {
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('SUBTOTAL_AUTO_ADD_SUBTOTAL_ON_ADDING_NEW_TITLE');
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans('SUBTOTAL_ALLOW_EXTRAFIELDS_ON_TITLE').'</td>';
@@ -349,9 +349,9 @@ function showParameters() {
 	// TODO ajouter ici la partie fournisseur en ce basant sur les 3 conf du dessus
 
 	print '</table><br />';
-	
-	
-	
+
+
+
 	$var=false;
 	print '<table class="noborder" width="100%">';
 	print '<tr class="liste_titre">';
@@ -359,7 +359,7 @@ function showParameters() {
 	print '<td align="center" width="20">&nbsp;</td>';
 	print '<td align="center" width="100">'.$langs->trans("Value").'</td>'."\n";
 	print '</tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans('SUBTOTAL_KEEP_RECAP_FILE').'</td>';
@@ -367,7 +367,7 @@ function showParameters() {
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('SUBTOTAL_KEEP_RECAP_FILE');
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans('SUBTOTAL_PROPAL_ADD_RECAP').'</td>';
@@ -375,7 +375,7 @@ function showParameters() {
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('SUBTOTAL_PROPAL_ADD_RECAP');
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans('SUBTOTAL_COMMANDE_ADD_RECAP').'</td>';
@@ -383,8 +383,8 @@ function showParameters() {
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('SUBTOTAL_COMMANDE_ADD_RECAP');
 	print '</td></tr>';
-	
-	
+
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans('SUBTOTAL_INVOICE_ADD_RECAP').'</td>';
@@ -392,18 +392,18 @@ function showParameters() {
 	print '<td align="center" width="300">';
 	print ajax_constantonoff('SUBTOTAL_INVOICE_ADD_RECAP');
 	print '</td></tr>';
-	
+
 	print '</table>';
-	
+
 ?>
 	<br />
-		
+
 	<table width="100%" class="noborder" style="background-color: #fff;">
 		<tr class="liste_titre">
 			<td colspan="2">Paramètrage de l'option "Cacher le prix des lignes des ensembles"</td>
 		</tr>
-		
-<?php 
+
+<?php
 	print '<tr class="oddeven" >';
 	print '<td>'.$langs->trans('SUBTOTAL_HIDE_PRICE_DEFAULT_CHECKED').'</td>';
 	print '<td align="center" >';
@@ -422,7 +422,7 @@ function showParameters() {
 				</form>
 			</td>
 		</tr>
-		
+
 		<tr class="pair">
 			<td>Masquer les totaux</td>
 			<td style="text-align: right;">
@@ -432,9 +432,9 @@ function showParameters() {
 					<?php echo $html->selectyesno("SUBTOTAL_HIDE_DOCUMENT_TOTAL",$conf->global->SUBTOTAL_HIDE_DOCUMENT_TOTAL,1); ?>
 					<input type="submit" class="button" value="<?php echo $langs->trans("Modify") ?>">
 				</form>
-			</td>				
+			</td>
 		</tr>
-		
+
 		<?php if ($conf->clilacevenements->enabled) { ?>
 			<tr>
 				<td>Afficher la quantité sur les lignes de sous-total (uniquement dans le cas d'un produit virtuel ajouté)</td>
@@ -445,9 +445,9 @@ function showParameters() {
 						<?php echo $html->selectyesno("SUBTOTAL_SHOW_QTY_ON_TITLES",$conf->global->SUBTOTAL_SHOW_QTY_ON_TITLES,1); ?>
 						<input type="submit" class="button" value="<?php echo $langs->trans("Modify") ?>">
 					</form>
-				</td>				
+				</td>
 			</tr>
-			
+
 			<tr class="pair">
 				<td>Masquer uniquement les prix pour les produits se trouvant dans un ensemble</td>
 				<td style="text-align: right;">
@@ -457,11 +457,11 @@ function showParameters() {
 						<?php echo $html->selectyesno("SUBTOTAL_ONLY_HIDE_SUBPRODUCTS_PRICES",$conf->global->SUBTOTAL_ONLY_HIDE_SUBPRODUCTS_PRICES,1); ?>
 						<input type="submit" class="button" value="<?php echo $langs->trans("Modify") ?>">
 					</form>
-				</td>				
+				</td>
 			</tr>
-		<?php } ?>	
+		<?php } ?>
 	</table>
-	
+
 	<br /><br />
 	<?php
 }

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -44,7 +44,7 @@ class ActionsSubtotal
 			if ((float) DOL_VERSION >= 6.0)
 			{
 				$value = '';
-				$sql = 'SELECT content FROM '.MAIN_DB_PREFIX.'c_subtotal_free_text WHERE rowid = '.GETPOST('rowid');
+				$sql = 'SELECT content FROM '.MAIN_DB_PREFIX.'c_subtotal_free_text WHERE rowid = '.GETPOST('rowid', 'int');
 				$resql = $this->db->query($sql);
 				if ($resql && ($obj = $this->db->fetch_object($resql))) $value = $obj->content;
 			}
@@ -144,7 +144,7 @@ class ActionsSubtotal
 					$level = GETPOST('level', 'int'); //New avec SUBTOTAL_USE_NEW_FORMAT
 
 					if($action=='add_title_line') {
-						$title = GETPOST('title');
+						$title = GETPOST('title', 'none');
 						if(empty($title)) $title = $langs->trans('title');
 						$qty = $level<1 ? 1 : $level ;
 					}
@@ -164,7 +164,7 @@ class ActionsSubtotal
 						$qty = 50;
 					}
 					else if($action=='add_subtitle_line') {
-						$title = GETPOST('title');
+						$title = GETPOST('title', 'none');
 						if(empty($title)) $title = $langs->trans('subtitle');
 						$qty = 2;
 					}
@@ -173,7 +173,7 @@ class ActionsSubtotal
 						$qty = 98;
 					}
 					else {
-						$title = GETPOST('title') ? GETPOST('title') : $langs->trans('SubTotal');
+						$title = GETPOST('title', 'none') ? GETPOST('title', 'none') : $langs->trans('SubTotal');
 						$qty = $level ? 100-$level : 99;
 					}
 					dol_include_once('/subtotal/class/subtotal.class.php');
@@ -400,7 +400,7 @@ class ActionsSubtotal
 
 		global $conf, $langs, $bc;
 
-		$action = GETPOST('action');
+		$action = GETPOST('action', 'none');
 		$TContext = explode(':',$parameters['context']);
 		if (
 				in_array('invoicecard',$TContext)
@@ -456,7 +456,7 @@ class ActionsSubtotal
 						<tr '.$bc[$var].'>
 							<td colspan="4" align="right">
 								<label for="subtotal_add_recap">'.$langs->trans('subtotal_add_recap').'</label>
-								<input type="checkbox" id="subtotal_add_recap" name="subtotal_add_recap" value="1" '.( GETPOST('subtotal_add_recap') ? 'checked="checked"' : '' ).' />
+								<input type="checkbox" id="subtotal_add_recap" name="subtotal_add_recap" value="1" '.( GETPOST('subtotal_add_recap', 'none') ? 'checked="checked"' : '' ).' />
 							</td>
 						</tr>';
 				}
@@ -583,7 +583,7 @@ class ActionsSubtotal
 		dol_include_once('/subtotal/lib/subtotal.lib.php');
 		require_once DOL_DOCUMENT_ROOT . '/core/class/extrafields.class.php';
 
-		$showBlockExtrafields = GETPOST('showBlockExtrafields');
+		$showBlockExtrafields = GETPOST('showBlockExtrafields', 'none');
 
 		if($object->element=='facture') $idvar = 'facid';
 		else $idvar = 'id';
@@ -666,15 +666,15 @@ class ActionsSubtotal
 
 				global $hideprices;
 
-				$hideInnerLines = (int)GETPOST('hideInnerLines');
+				$hideInnerLines = GETPOST('hideInnerLines', 'int');
 				if(empty($_SESSION[$sessname]) || !is_array($_SESSION[$sessname][$object->id]) ) $_SESSION[$sessname] = array(); // prevent old system
 				$_SESSION[$sessname][$object->id] = $hideInnerLines;
 
-				$hidedetails= (int)GETPOST('hidedetails');
+				$hidedetails= GETPOST('hidedetails', 'int');
 				if(empty($_SESSION[$sessname2]) || !is_array($_SESSION[$sessname2][$object->id]) ) $_SESSION[$sessname2] = array(); // prevent old system
 				$_SESSION[$sessname2][$object->id] = $hidedetails;
 
-				$hideprices= (int)GETPOST('hideprices');
+				$hideprices= GETPOST('hideprices', 'int');
 				if(empty($_SESSION[$sessname3]) || !is_array($_SESSION[$sessname3][$object->id]) ) $_SESSION[$sessname3] = array(); // prevent old system
 				$_SESSION[$sessname3][$object->id] = $hideprices;
 
@@ -694,9 +694,9 @@ class ActionsSubtotal
 	        }
 
 		}
-		else if($action === 'confirm_delete_all_lines' && GETPOST('confirm')=='yes') {
+		else if($action === 'confirm_delete_all_lines' && GETPOST('confirm', 'none')=='yes') {
 
-			$Tab = TSubtotal::getLinesFromTitleId($object, GETPOST('lineid'), true);
+			$Tab = TSubtotal::getLinesFromTitleId($object, GETPOST('lineid', 'int'), true);
 			foreach($Tab as $line) {
 				$idLine = $line->id;
 				/**
@@ -848,7 +848,7 @@ class ActionsSubtotal
 		$sign=1;
 		if (isset($object->type) && $object->type == 2 && ! empty($conf->global->INVOICE_POSITIVE_CREDIT_NOTE)) $sign=-1;
 
-		if (GETPOST('action') == 'builddoc') $builddoc = true;
+		if (GETPOST('action', 'none') == 'builddoc') $builddoc = true;
 		else $builddoc = false;
 
 		dol_include_once('/subtotal/class/subtotal.class.php');
@@ -914,14 +914,14 @@ class ActionsSubtotal
 	function pdf_add_total(&$pdf,&$object, &$line, $label, $description,$posx, $posy, $w, $h) {
 		global $conf,$subtotal_last_title_posy;
 
-		$hideInnerLines = (int)GETPOST('hideInnerLines');
+		$hideInnerLines = GETPOST('hideInnerLines', 'int');
 		if (!empty($conf->global->SUBTOTAL_ONE_LINE_IF_HIDE_INNERLINES) && $hideInnerLines && !empty($subtotal_last_title_posy))
 		{
 			$posy = $subtotal_last_title_posy;
 			$subtotal_last_title_posy = null;
 		}
 
-		$hidePriceOnSubtotalLines = (int) GETPOST('hide_price_on_subtotal_lines');
+		$hidePriceOnSubtotalLines = GETPOST('hide_price_on_subtotal_lines', 'int');
 
 		if($object->element == 'shipping' || $object->element == 'delivery')
 		{
@@ -986,7 +986,7 @@ class ActionsSubtotal
 
 			if($total_to_print !== '') {
 
-				if (GETPOST('hideInnerLines'))
+				if (GETPOST('hideInnerLines', 'int'))
 				{
 					// Dans le cas des lignes cachés, le calcul est déjà fait dans la méthode beforePDFCreation et les lignes de sous-totaux sont déjà renseignés
 //					$line->TTotal_tva
@@ -1042,7 +1042,7 @@ class ActionsSubtotal
 		$subtotal_last_title_posy = $posy;
 		$pdf->SetXY ($posx, $posy);
 
-		$hideInnerLines = (int)GETPOST('hideInnerLines');
+		$hideInnerLines = GETPOST('hideInnerLines', 'int');
 
 
 
@@ -1132,8 +1132,8 @@ class ActionsSubtotal
 		}
 		elseif (!empty($conf->global->SUBTOTAL_IF_HIDE_PRICES_SHOW_QTY))
 		{
-			$hideInnerLines = (int)GETPOST('hideInnerLines');
-			$hidedetails = (int)GETPOST('hidedetails');
+			$hideInnerLines = GETPOST('hideInnerLines', 'int');
+			$hidedetails = GETPOST('hidedetails', 'int');
 			if (empty($hideInnerLines) && !empty($hidedetails))
 			{
 				$this->resprints = $object->lines[$parameters['i']]->qty;
@@ -1199,7 +1199,7 @@ class ActionsSubtotal
 				}
 			}
 		}
-		if ((int)GETPOST('hideInnerLines') && !empty($conf->global->SUBTOTAL_REPLACE_WITH_VAT_IF_HIDE_INNERLINES)){
+		if (GETPOST('hideInnerLines', 'int') && !empty($conf->global->SUBTOTAL_REPLACE_WITH_VAT_IF_HIDE_INNERLINES)){
 		    $this->resprints = price($object->lines[$i]->total_ht);
 		}
 
@@ -1656,7 +1656,7 @@ class ActionsSubtotal
 
 	function setDocTVA(&$pdf, &$object) {
 
-		$hidedetails = (int)GETPOST('hidedetails');
+		$hidedetails = GETPOST('hidedetails', 'int');
 
 		if(empty($hidedetails)) return false;
 
@@ -1701,8 +1701,8 @@ class ActionsSubtotal
 			}
         }
 
-		$hideInnerLines = (int)GETPOST('hideInnerLines');
-		$hidedetails = (int)GETPOST('hidedetails');
+		$hideInnerLines = GETPOST('hideInnerLines', 'int');
+		$hidedetails = GETPOST('hidedetails', 'int');
 
 		if ($hideInnerLines) { // si c une ligne de titre
 	    	$fk_parent_line=0;
@@ -1857,8 +1857,8 @@ class ActionsSubtotal
 			${$key} = $value;
 		}
 
-		$hideInnerLines = (int)GETPOST('hideInnerLines');
-		$hidedetails = (int)GETPOST('hidedetails');
+		$hideInnerLines = GETPOST('hideInnerLines', 'int');
+		$hidedetails = GETPOST('hidedetails', 'int');
 
 		if($this->isModSubtotalLine($parameters,$object) ){
 
@@ -2070,7 +2070,7 @@ class ActionsSubtotal
 		if($line->special_code!=$this->module_number || $line->product_type!=9) {
 			if ($object->statut == 0  && $createRight && !empty($conf->global->SUBTOTAL_ALLOW_DUPLICATE_LINE) && $object->element !== 'invoice_supplier')
             {
-                if(!(TSubtotal::isModSubtotalLine($line)) && ( $line->fk_prev_id === null ) && !($action == "editline" && GETPOST('lineid') == $line->id)) {
+                if(!(TSubtotal::isModSubtotalLine($line)) && ( $line->fk_prev_id === null ) && !($action == "editline" && GETPOST('lineid', 'int') == $line->id)) {
                     echo '<a name="duplicate-'.$line->id.'" href="' . $_SERVER['PHP_SELF'] . '?' . $idvar . '=' . $object->id . '&action=duplicate&lineid=' . $line->id . '"><i class="fa fa-clone" aria-hidden="true"></i></a>';
 
                     ?>
@@ -2167,7 +2167,7 @@ class ActionsSubtotal
 				<?php } ?>
 
 				<td colspan="<?php echo $colspan; ?>" style="<?php TSubtotal::isFreeText($line) ? '' : 'font-weight:bold;'; ?>  <?php echo ($line->qty>90)?'text-align:right':'' ?> "><?php
-					if($action=='editline' && GETPOST('lineid') == $line->id && TSubtotal::isModSubtotalLine($line) ) {
+					if($action=='editline' && GETPOST('lineid', 'int') == $line->id && TSubtotal::isModSubtotalLine($line) ) {
 
 						$params=array('line'=>$line);
 						$reshook=$hookmanager->executeHooks('formEditProductOptions',$params,$object,$action);
@@ -2373,7 +2373,7 @@ class ActionsSubtotal
 				<?php
 				if ($action != 'selectlines') {
 
-					if($action=='editline' && GETPOST('lineid') == $line->id && TSubtotal::isModSubtotalLine($line) ) {
+					if($action=='editline' && GETPOST('lineid', 'int') == $line->id && TSubtotal::isModSubtotalLine($line) ) {
 						?>
 						<input id="savelinebutton" class="button" type="submit" name="save" value="<?php echo $langs->trans('Save') ?>" />
 						<br />
@@ -2482,7 +2482,7 @@ class ActionsSubtotal
 				$extralabelsline = $extrafieldsline->fetch_name_optionals_label($object->table_element_line);
 
 				$colspan+=3; $mode = 'view';
-				if($action === 'editline' && $line->rowid == GETPOST('lineid')) $mode = 'edit';
+				if($action === 'editline' && $line->rowid == GETPOST('lineid', 'int')) $mode = 'edit';
 
 				$ex_element = $line->element;
 				$line->element = 'tr_extrafield_title '.$line->element; // Pour pouvoir manipuler ces tr
@@ -3007,7 +3007,7 @@ class ActionsSubtotal
 
 		if ((!empty($conf->global->SUBTOTAL_PROPAL_ADD_RECAP) && $object->element == 'propal') || (!empty($conf->global->SUBTOTAL_COMMANDE_ADD_RECAP) && $object->element == 'commande') || (!empty($conf->global->SUBTOTAL_INVOICE_ADD_RECAP) && $object->element == 'facture'))
 		{
-			if (GETPOST('subtotal_add_recap')) {
+			if (GETPOST('subtotal_add_recap', 'none')) {
 				dol_include_once('/subtotal/class/subtotal.class.php');
 				TSubtotal::addRecapPage($parameters, $pdf);
 			}

--- a/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
+++ b/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
@@ -208,7 +208,7 @@ class Interfacesubtotaltrigger extends DolibarrTriggers
             }
 		    else
             {
-			    $subtotal_add_title_bloc_from_orderstoinvoice = GETPOST('subtotal_add_title_bloc_from_orderstoinvoice');
+			    $subtotal_add_title_bloc_from_orderstoinvoice = GETPOST('subtotal_add_title_bloc_from_orderstoinvoice', 'none');
 			    if (!empty($subtotal_add_title_bloc_from_orderstoinvoice))
 			    {
 				    global $subtotal_current_rang, $subtotal_bloc_previous_fk_commande, $subtotal_bloc_already_add_title, $subtotal_bloc_already_add_st;
@@ -272,7 +272,7 @@ class Interfacesubtotaltrigger extends DolibarrTriggers
 
 		if ($action == 'LINEBILL_UPDATE')
 		{
-			if (GETPOST('all_progress') && TSubtotal::isModSubtotalLine($object))
+			if (GETPOST('all_progress', 'none') && TSubtotal::isModSubtotalLine($object))
 			{
 				$object->situation_percent = 0;
 				$object->update($user, true); // notrigger pour éviter la boucle infinie
@@ -283,8 +283,8 @@ class Interfacesubtotaltrigger extends DolibarrTriggers
 		{
             if(! function_exists('_updateLineNC')) dol_include_once('/subtotal/lib/subtotal.lib.php');
 
-			$doli_action = GETPOST('action');
-			$set = GETPOST('set');
+			$doli_action = GETPOST('action', 'none');
+			$set = GETPOST('set', 'none');
 			if ( (in_array($doli_action, array('updateligne', 'updateline', 'addline', 'add', 'create', 'setstatut', 'save_nomenclature')) || $set == 'defaultTVA') && !TSubtotal::isTitle($object) && !TSubtotal::isSubtotal($object) && in_array($object->element, array('propaldet', 'commandedet', 'facturedet')))
 			{
 				 dol_syslog(
@@ -544,7 +544,7 @@ class Interfacesubtotaltrigger extends DolibarrTriggers
                 "Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id
             );
 
-			$doli_action = GETPOST('action');
+			$doli_action = GETPOST('action', 'none');
 
 			if (!empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS) && in_array($doli_action, array('confirm_clone')))
 			{

--- a/lib/subtotal.lib.php
+++ b/lib/subtotal.lib.php
@@ -49,21 +49,21 @@ function subtotalAdminPrepareHead()
 function getHtmlSelectTitle(&$object, $showLabel=false)
 {
 	global $langs;
-	
+
 	require_once DOL_DOCUMENT_ROOT . '/core/lib/functions.lib.php';
 	dol_include_once('/subtotal/class/subtotal.class.php');
 	$TTitle = TSubtotal::getAllTitleFromDocument($object);
 	$html = '';
 	if ($showLabel) $html.= '<label for="under_title">'.$langs->trans('subtotalLabelForUnderTitle').'</label>';
 	$html.= '<select onChange="$(\'select[name=under_title]\').val(this.value);" name="under_title" class="under_title minwidth200"><option value="-1"></option>';
-	
+
 	$nbsp = '&nbsp;';
 	foreach ($TTitle as &$line)
 	{
 		$str = str_repeat($nbsp, ($line->qty - 1) * 3);
 		$html .= '<option value="'.$line->rang.'">'.$str.(!empty($line->label) ? $line->label : dol_trunc($line->desc, 30)).'</option>';
 	}
-	
+
 	$html .= '</select>';
 	return $html;
 }
@@ -71,12 +71,12 @@ function getHtmlSelectTitle(&$object, $showLabel=false)
 function getTFreeText()
 {
 	global $db,$conf;
-	
+
 	$TFreeText = array();
-	
+
 	$sql = 'SELECT rowid, label, content, active, entity FROM '.MAIN_DB_PREFIX.'c_subtotal_free_text WHERE active = 1 AND entity = '.$conf->entity.' ORDER BY label';
 	$resql = $db->query($sql);
-	
+
 	if ($resql)
 	{
 		while ($row = $db->fetch_object($resql))
@@ -84,14 +84,14 @@ function getTFreeText()
 			$TFreeText[$row->rowid] = $row;
 		}
 	}
-	
+
 	return $TFreeText;
 }
 
 function getHtmlSelectFreeText($withEmpty=true)
 {
 	global $langs;
-	
+
 	$TFreeText = getTFreeText();
 	$html = '<label for="free_text">'.$langs->trans('subtotalLabelForFreeText').'</label>';
 	$html.= '<select onChange="getTFreeText($(this));" name="free_text" class="minwidth200">';
@@ -129,11 +129,11 @@ function _updateSubtotalLine(&$object, &$line)
 {
 	global $conf;
 
-	$label = GETPOST('line-title');
+	$label = GETPOST('line-title', 'none');
 	$description = ($line->qty>90) ? '' : GETPOST('line-description', 'restricthtml');
-	$pagebreak = (int) GETPOST('line-pagebreak');
-    $showTotalHT = (int) GETPOST('line-showTotalHT');
-    $showReduc = (int) GETPOST('line-showReduc');
+	$pagebreak = GETPOST('line-pagebreak', 'int');
+    $showTotalHT = GETPOST('line-showTotalHT', 'int');
+    $showReduc = GETPOST('line-showReduc', 'int');
 
 	$level = GETPOST('subtotal_level', 'int');
 	if (!empty($level))
@@ -143,7 +143,7 @@ function _updateSubtotalLine(&$object, &$line)
 	}
     $line->array_options['options_show_total_ht'] = $showTotalHT;
     $line->array_options['options_show_reduc'] = $showReduc;
-	
+
 	$res = TSubtotal::doUpdateLine($object, $line->id, $description, 0, $line->qty, 0, '', '', 0, 9, 0, 0, 'HT', $pagebreak, 0, 1, null, 0, $label, TSubtotal::$module_number, $line->array_options);
 
 	$TKey = null;
@@ -183,12 +183,12 @@ function _updateSubtotalLine(&$object, &$line)
 function _updateSubtotalBloc($object, $line)
 {
 	global $conf,$langs;
-	
+
 	$subtotal_tva_tx = $subtotal_tva_tx_init = GETPOST('subtotal_tva_tx', 'int');
 	$subtotal_progress = $subtotal_progress_init = GETPOST('subtotal_progress', 'int');
 	$array_options = $line->array_options;
-	$showBlockExtrafields = GETPOST('showBlockExtrafields');
-	
+	$showBlockExtrafields = GETPOST('showBlockExtrafields', 'none');
+
 	if ($subtotal_tva_tx != '' || $subtotal_progress != '' || (!empty($showBlockExtrafields) && !empty($array_options)))
 	{
 		$error_progress = $nb_progress_update = $nb_progress_not_updated = 0;
@@ -198,7 +198,7 @@ function _updateSubtotalBloc($object, $line)
 			if (!TSubtotal::isModSubtotalLine($line))
 			{
 				$subtotal_tva_tx = $subtotal_tva_tx_init; // ré-init car la variable peut évoluer
-					
+
 				if (!empty($showBlockExtrafields)) $line->array_options = $array_options;
 				if ($subtotal_tva_tx == '') $subtotal_tva_tx = $line->tva_tx;
 				if ($object->element == 'facture' && !empty($conf->global->INVOICE_USE_SITUATION) && $object->type == Facture::TYPE_SITUATION)
@@ -215,7 +215,7 @@ function _updateSubtotalBloc($object, $line)
 						}
 					}
 				}
-				
+
 				$res = TSubtotal::doUpdateLine($object, $line->id, $line->desc, $line->subprice, $line->qty, $line->remise_percent, $line->date_start, $line->date_end, $subtotal_tva_tx, $line->product_type, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->fk_parent_line, $line->skip_update_total, $line->fk_fournprice, $line->pa_ht, $line->label, $line->special_code, $line->array_options, $subtotal_progress, $line->fk_unit);
 
 				if ($res > 0) $success_updated_line++;
@@ -224,26 +224,26 @@ function _updateSubtotalBloc($object, $line)
 		}
 
 		if ($nb_progress_not_updated > 0) setEventMessage($langs->trans('subtotal_nb_progress_not_updated', $nb_progress_not_updated), 'warnings');
-		
+
 		if ($success_updated_line > 0) setEventMessage($langs->trans('subtotal_success_updated_line', $success_updated_line));
 		if ($error_updated_line > 0)
 		{
 			setEventMessage($langs->trans('subtotal_error_updated_line', $error_updated_line), 'errors');
 			return -$error_updated_line;
 		}
-		
+
 		return $success_updated_line;
 	}
-	
+
 	return 0;
 }
 
 function _createExtraComprisNonCompris()
 {
 	global $db;
-	
+
 	dol_include_once('/core/class/extrafields.class.php');
-	
+
 	$extra = new ExtraFields($db); // propaldet, commandedet, facturedet
 	$extra->addExtraField('subtotal_nc', 'Non compris', 'varchar', 0, 255, 'propaldet', 0, 0, '', unserialize('a:1:{s:7:"options";a:1:{s:0:"";N;}}'), 0, '', 0, 1);
 	$extra->addExtraField('subtotal_nc', 'Non compris', 'varchar', 0, 255, 'commandedet', 0, 0, '', unserialize('a:1:{s:7:"options";a:1:{s:0:"";N;}}'), 0, '', 0, 1);
@@ -254,20 +254,20 @@ function _createExtraComprisNonCompris()
 }
 
 
-	
+
 /**
  * Maj du bloc pour forcer le total_tva et total_ht à 0 et recalculer le total du document
- * 
+ *
  * @param	$lineid			= title lineid
- * @param	$subtotal_nc	0 = "Compris" prise en compte des totaux des lignes; 1 = "Non compris" non prise en compte des totaux du bloc; null = update de toutes les lignes 
+ * @param	$subtotal_nc	0 = "Compris" prise en compte des totaux des lignes; 1 = "Non compris" non prise en compte des totaux du bloc; null = update de toutes les lignes
  */
 function _updateLineNC($element, $elementid, $lineid, $subtotal_nc=null, $notrigger = 0)
 {
 	global $db,$langs,$tmp_object_nc;
-	
+
 	$error = 0;
 	if (empty($element)) $error++;
-	
+
 	if (!$error)
 	{
 		if (!empty($tmp_object_nc) && $tmp_object_nc->element == $element && $tmp_object_nc->id == $elementid)
@@ -277,28 +277,28 @@ function _updateLineNC($element, $elementid, $lineid, $subtotal_nc=null, $notrig
 		else
 		{
 			$classname = ucfirst($element);
-			
+
 			switch ($element) {
 			    case 'supplier_proposal':
 			        $classname = 'SupplierProposal';
 			        break;
-			        
+
 			    case 'order_supplier':
 			        $classname = 'CommandeFournisseur';
 			        break;
-			        
+
 			    case 'invoice_supplier':
 			        $classname = 'FactureFournisseur';
 			        break;
 			}
-			
+
 			$object = new $classname($db); // Propal | Commande | Facture
 			$res = $object->fetch($elementid);
 			if ($res < 0) $error++;
 			else $tmp_object_nc = $object;
 		}
 	}
-	
+
 	if (!$error)
 	{
 		foreach ($object->lines as &$l)
@@ -308,11 +308,11 @@ function _updateLineNC($element, $elementid, $lineid, $subtotal_nc=null, $notrig
 				break;
 			}
 		}
-		
+
 		if (!empty($line))
 		{
 			$db->begin();
-			
+
 			if(TSubtotal::isModSubtotalLine($line))
 			{
 				if(TSubtotal::isTitle($line)) {
@@ -328,10 +328,10 @@ function _updateLineNC($element, $elementid, $lineid, $subtotal_nc=null, $notrig
 			{
 				$res = doUpdate($object, $line, $subtotal_nc, $notrigger);
 			}
-			
+
 			$res = $object->update_price(1);
 			if ($res <= 0) $error++;
-			
+
 			if (!$error)
 			{
 				setEventMessage($langs->trans('subtotal_update_nc_success'));
@@ -349,11 +349,11 @@ function _updateLineNC($element, $elementid, $lineid, $subtotal_nc=null, $notrig
 function doUpdate(&$object, &$line, $subtotal_nc, $notrigger = 0)
 {
 	global $user;
-	
+
 	if (TSubtotal::isFreeText($line) || TSubtotal::isSubtotal($line)) return 1;
 	// Update extrafield et total
 	if(! empty($subtotal_nc)) {
-		$line->total_ht = $line->total_tva = $line->total_ttc = $line->total_localtax1 = $line->total_localtax2 = 
+		$line->total_ht = $line->total_tva = $line->total_ttc = $line->total_localtax1 = $line->total_localtax2 =
 			$line->multicurrency_total_ht = $line->multicurrency_total_tva = $line->multicurrency_total_ttc = 0;
 
 		$line->array_options['options_subtotal_nc'] = 1;
@@ -364,7 +364,7 @@ function doUpdate(&$object, &$line, $subtotal_nc, $notrigger = 0)
 	else {
 	    if(in_array($object->element, array('invoice_supplier', 'order_supplier', 'supplier_proposal'))) {
 	        if(empty($line->label)) $line->label = $line->description; // supplier lines don't have the field label
-	        
+
 	        require_once(DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php');
 	        $extrafields=new ExtraFields($object->db);
 	        $extralabels=$extrafields->fetch_name_optionals_label($object->table_element_line,true);
@@ -374,7 +374,7 @@ function doUpdate(&$object, &$line, $subtotal_nc, $notrigger = 0)
 		if($object->element == 'order_supplier') $line->update($user);
 		$res = TSubtotal::doUpdateLine($object, $line->id, $line->desc, $line->subprice, $line->qty, $line->remise_percent, $line->date_start, $line->date_end, $line->tva_tx, $line->product_type, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->fk_parent_line, $line->skip_update_total, $line->fk_fournprice, $line->pa_ht, $line->label, $line->special_code, $line->array_options, $line->situation_percent, $line->fk_unit, $notrigger);
 	}
-	
+
 	return $res;
 }
 

--- a/script/interface.php
+++ b/script/interface.php
@@ -1,6 +1,6 @@
 <?php
 	require '../config.php';
-	
+
 	dol_include_once('/subtotal/lib/subtotal.lib.php');
 	dol_include_once('/subtotal/class/subtotal.class.php');
 	dol_include_once('/comm/propal/class/propal.class.php');
@@ -9,19 +9,19 @@
 	dol_include_once('/fourn/class/fournisseur.commande.class.php');
 	dol_include_once('/supplier_proposal/class/supplier_proposal.class.php');
 	dol_include_once('/fourn/class/fournisseur.facture.class.php');
-	
-	$get=GETPOST('get');
-	$set=GETPOST('set');
-	
+
+	$get=GETPOST('get', 'none');
+	$set=GETPOST('set', 'none');
+
 	switch ($get) {
 		default:
 			break;
 	}
-	
+
 	switch ($set) {
 		case 'updateLineNC': // Gestion du Compris/Non Compris via les titres et/ou lignes
-			echo json_encode( _updateLineNC(GETPOST('element'), GETPOST('elementid'), GETPOST('lineid'), GETPOST('subtotal_nc')) );
-			
+			echo json_encode( _updateLineNC(GETPOST('element', 'none'), GETPOST('elementid', 'none'), GETPOST('lineid', 'none'), GETPOST('subtotal_nc', 'none')) );
+
 			break;
 		default:
 			break;


### PR DESCRIPTION
# FIX

A partir de la v12 le paramètre check de la fonction GETPOST est alphanohtml par défaut ce qui fait que tous nos inputs ayant une balise html sont vidés.

Modification (et typage) de tous les paramètres check manquants.