### PR TITLE
FIX exclude virtual products in total

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -893,10 +893,12 @@ class ActionsSubtotal
                 }
                 else
                 {
-                    $total += $l->total_ht;
-                    $total_tva += $l->total_tva;
-                    $TTotal_tva[$l->tva_tx] += $l->total_tva;
-                    $total_ttc += $l->total_ttc;
+			if ($l->product_type != 9) {
+                    		$total += $l->total_ht;
+                    		$total_tva += $l->total_tva;
+                    		$TTotal_tva[$l->tva_tx] += $l->total_tva;
+                    		$total_ttc += $l->total_ttc;
+			}
                 }
             }
 		}


### PR DESCRIPTION
FIX exclude virtual products in total
- no need to add virtual products amounts in total (already computed in product line amount)