### PR TITLE
Saut de ligne pour titre ou ligne texte libre

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,9 @@
-# CHANGELOG FOR XXXXXX MODULE
+# CHANGELOG FOR SUBTOTAL MODULE
 
 ## Not Released
 
 
-## 3.2.1 - 15/04/2021
 
-- FIX : Text or title line break PDF
+## Version 3.2
+
+- FIX : Text or title line break PDF *15/04/2021* - 3.2.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,8 @@
+# CHANGELOG FOR XXXXXX MODULE
+
+## Not Released
+
+
+## 3.2.1 - 15/04/2021
+
+- FIX : Text or title line break PDF

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1324,9 +1324,10 @@ class ActionsSubtotal
 
 				$line = &$object->lines[$i];
 
-				if($line->info_bits>0) { // PAGE BREAK
+				$margin = $pdf->getMargins();
+				if(!empty($margin) && $line->info_bits>0) {
 					$pdf->addPage();
-					$posy = $pdf->GetY();
+					$posy = $margin['top'];
 				}
 
 				$label = $line->label;
@@ -1336,6 +1337,7 @@ class ActionsSubtotal
 					$label = $description;
 					$description='';
 				}
+
 
 				if($line->qty>90) {
 
@@ -1355,6 +1357,7 @@ class ActionsSubtotal
 
 					$posy = $pdf->GetY();
 					return 1;
+
 				}
 				else if ($line->qty < 10) {
 					$pageBefore = $pdf->getPage();
@@ -1375,6 +1378,15 @@ class ActionsSubtotal
 					}
 				*/
 					$posy = $pdf->GetY();
+					return 1;
+				} else {
+
+					$labelproductservice = pdf_getlinedesc($object, $i, $outputlangs, $parameters['hideref'], $parameters['hidedesc'], $parameters['issupplierline']);
+
+					$labelproductservice = preg_replace('/(<img[^>]*src=")([^"]*)(&amp;)([^"]*")/', '\1\2&\4', $labelproductservice, -1, $nbrep);
+
+					$pdf->writeHTMLCell($parameters['w'], $parameters['h'], $parameters['posx'], $posy, $outputlangs->convToOutputCharset($labelproductservice), 0, 1, false, true, 'J', true);
+
 					return 1;
 				}
 //	if($line->rowid==47) exit;

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1379,7 +1379,7 @@ class ActionsSubtotal
 				*/
 					$posy = $pdf->GetY();
 					return 1;
-				} else {
+				} elseif(!empty($margin)) {
 
 					$labelproductservice = pdf_getlinedesc($object, $i, $outputlangs, $parameters['hideref'], $parameters['hidedesc'], $parameters['issupplierline']);
 

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -63,7 +63,7 @@ class modSubtotal extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Module permettant l'ajout de sous-totaux et sous-totaux intermédiaires et le déplacement d'une ligne aisée de l'un dans l'autre";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '3.2.0';
+        $this->version = '3.2.1';
         // Key used in llx_const table to save module status enabled/disabled
         // (where MYMODULE is value of property name of module in uppercase)
         $this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);


### PR DESCRIPTION
Lorsqu'on cochait l'option "saut de ligne" sur les lignes de type texte ou titre, le saut de ligne se faisait mais n'était pas placé au bon endroit. 

En effet, le posY n'était pas le bon => reprise du hook de subtotal pour corriger cette anomalie. 