### PR TITLE
FIX 3.6.8: feature to add a title block per order in the "bill orders" mass action was broken

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 
 ## Version 3.6
+- FIX : checkbox to add a subtotal title block per order on invoices using the "Bill orders" feature was broken by
+        core changes in Dolibarr *12/11/2021* - 3.6.8
 - FIX : addition of a conf allowing to add the subtotal line or not when creating an expedition from an order *12/07/2021* - 3.6.7 
 - FIX : Clone icon compatibility *08/06/2021* - 3.6.6
 - FIX : Uniformize module descriptor's editor, editor_url and family fields *2021-06-08* - 3.6.5

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -99,7 +99,7 @@ class ActionsSubtotal
 		return 0;
 	}
 
-	/** Overloading the doActions function : replacing the parent's function with the one below
+	/** Overloading the formObjectOptions function : replacing the parent's function with the one below
 	 * @param      $parameters  array           meta datas of the hook (context, etc...)
 	 * @param      $object      CommonObject    the object you want to process (an invoice if you are in invoice module, a propale in propale's module, etc...)
 	 * @param      $action      string          current action (if set). Generally create or edit or null
@@ -208,18 +208,6 @@ class ActionsSubtotal
 					$this->printNewFormat($object, $conf, $langs, $idvar);
 				}
 			}
-		}
-		elseif ((!empty($parameters['currentcontext']) && $parameters['currentcontext'] == 'orderstoinvoice') || in_array('orderstoinvoice',$contexts) || in_array('orderstoinvoicesupplier',$contexts))
-		{
-			?>
-			<script type="text/javascript">
-				$(function() {
-					var tr = $("<tr><td><?php echo $langs->trans('subtotal_add_title_bloc_from_orderstoinvoice'); ?></td><td><input type='checkbox' value='1' name='subtotal_add_title_bloc_from_orderstoinvoice' checked='checked' /></td></tr>")
-					$("textarea[name=note]").closest('tr').after(tr);
-				});
-			</script>
-			<?php
-
 		}
 
 		return 0;
@@ -579,9 +567,18 @@ class ActionsSubtotal
 		return 0;
 	}
 
+	/**
+	 * @param array $parameters
+	 * @param CommonObject $object
+	 * @param string $action
+	 * @param HookManager $hookmanager
+	 * @return int|void
+	 */
 	function doActions($parameters, &$object, $action, $hookmanager)
 	{
 		global $db, $conf, $langs,$user;
+		$TContext = array();
+		if (isset($parameters['context'])) $TContext = explode(':', $parameters['context']);
 
 		dol_include_once('/subtotal/class/subtotal.class.php');
 		dol_include_once('/subtotal/lib/subtotal.lib.php');
@@ -775,6 +772,32 @@ class ActionsSubtotal
 			exit;
 		}
 
+		elseif ((!empty($parameters['currentcontext']) && $parameters['currentcontext'] == 'orderstoinvoice')
+				|| in_array('orderstoinvoice',$TContext)
+				|| in_array('orderstoinvoicesupplier',$TContext)
+				|| in_array('orderlist',$TContext)
+		) {
+			global $delayedhtmlcontent;
+			ob_start();
+			?>
+			<script type="text/javascript">
+				$(function() {
+					var tr = $("<tr><td><?php echo $langs->trans('subtotal_add_title_bloc_from_orderstoinvoice'); ?></td><td><input type='checkbox' value='1' name='subtotal_add_title_bloc_from_orderstoinvoice' checked='checked' /></td></tr>");
+					var $noteTextArea = $("textarea[name=note]");
+					if ($noteTextArea.length === 1) {
+						$noteTextArea.closest('tr').after(tr);
+						return;
+					}
+					var $inpCreateBills = $("#validate_invoices");
+					if ($inpCreateBills.length === 1) {
+						$inpCreateBills.closest('tr').after(tr);
+					}
+
+				});
+			</script>
+			<?php
+			$delayedhtmlcontent .= ob_get_clean();
+		}
 		return 0;
 	}
 

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -209,6 +209,10 @@ class ActionsSubtotal
 				}
 			}
 		}
+		elseif ((!empty($parameters['currentcontext']) && $parameters['currentcontext'] == 'orderstoinvoice') || in_array('orderstoinvoice',$contexts) || in_array('orderstoinvoicesupplier',$contexts))
+		{
+			$this->_billOrdersAddCheckBoxForTitleBlocks();
+		}
 
 		return 0;
 	}
@@ -777,26 +781,7 @@ class ActionsSubtotal
 				|| in_array('orderstoinvoicesupplier',$TContext)
 				|| in_array('orderlist',$TContext)
 		) {
-			global $delayedhtmlcontent;
-			ob_start();
-			?>
-			<script type="text/javascript">
-				$(function() {
-					var tr = $("<tr><td><?php echo $langs->trans('subtotal_add_title_bloc_from_orderstoinvoice'); ?></td><td><input type='checkbox' value='1' name='subtotal_add_title_bloc_from_orderstoinvoice' checked='checked' /></td></tr>");
-					var $noteTextArea = $("textarea[name=note]");
-					if ($noteTextArea.length === 1) {
-						$noteTextArea.closest('tr').after(tr);
-						return;
-					}
-					var $inpCreateBills = $("#validate_invoices");
-					if ($inpCreateBills.length === 1) {
-						$inpCreateBills.closest('tr').after(tr);
-					}
-
-				});
-			</script>
-			<?php
-			$delayedhtmlcontent .= ob_get_clean();
+			$this->_billOrdersAddCheckBoxForTitleBlocks();
 		}
 		return 0;
 	}
@@ -3352,5 +3337,32 @@ class ActionsSubtotal
 		$parameters['object']->subtotalPdfModelInfo->defaultTitlesFieldsStyle = $pdfDoc->subtotalPdfModelInfo->defaultTitlesFieldsStyle;
 		$parameters['object']->subtotalPdfModelInfo->defaultContentsFieldsStyle = $pdfDoc->subtotalPdfModelInfo->defaultContentsFieldsStyle;
 
+	}
+
+	/**
+	 * Add a checkbox on the bill orders forms (either the old orderstoinvoice or the new mass
+	 * action) to create a title block per invoiced order when creating one invoice per client.
+	 */
+	private function _billOrdersAddCheckBoxForTitleBlocks()
+	{
+		global $delayedhtmlcontent, $langs;
+		ob_start();
+		?>
+			<script type="text/javascript">
+				$(function() {
+					var tr = $("<tr><td><?php echo $langs->trans('subtotal_add_title_bloc_from_orderstoinvoice'); ?></td><td><input type='checkbox' value='1' name='subtotal_add_title_bloc_from_orderstoinvoice' checked='checked' /></td></tr>");
+					var $noteTextArea = $("textarea[name=note]");
+					if ($noteTextArea.length === 1) {
+						$noteTextArea.closest('tr').after(tr);
+						return;
+					}
+					var $inpCreateBills = $("#validate_invoices");
+					if ($inpCreateBills.length === 1) {
+						$inpCreateBills.closest('tr').after(tr);
+					}
+				});
+			</script>
+		<?php
+		$delayedhtmlcontent .= ob_get_clean();
 	}
 }

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -63,7 +63,7 @@ class modSubtotal extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Module permettant l'ajout de sous-totaux et sous-totaux intermédiaires et le déplacement d'une ligne aisée de l'un dans l'autre";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '3.6.7';
+        $this->version = '3.6.8';
 
         // Key used in llx_const table to save module status enabled/disabled
         // (where MYMODULE is value of property name of module in uppercase)


### PR DESCRIPTION
# FIX
In old Dolibarr versions there was a special page `orderstoinvoice.php`, which subtotal customized using a hook. In recent versions, this has been standardized into the "bill orders" mass action, but the customization by subtotal wasn't adapted to this mass action.