### PR TITLE
Fix da021066 unwanted line break in pdf for supplier documents

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 
 ## Version 3.6
+- FIX : Title lines broken on PDF for documents whose lines use the `desc` field instead of the `label` field (such as
+        supplier orders and invoices) *22/11/2021* - 3.6.9
 - FIX : checkbox to add a subtotal title block per order on invoices using the "Bill orders" feature was broken by
         core changes in Dolibarr *12/11/2021* - 3.6.8
 - FIX : addition of a conf allowing to add the subtotal line or not when creating an expedition from an order *12/07/2021* - 3.6.7 

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -396,14 +396,14 @@ class ActionsSubtotal
 		global $conf, $langs, $bc;
 
 		$action = GETPOST('action', 'none');
-		$TContext = explode(':',$parameters['context']);
+		$contextArray = explode(':',$parameters['context']);
 		if (
-				in_array('invoicecard',$TContext)
-		        || in_array('invoicesuppliercard',$TContext)
-				|| in_array('propalcard',$TContext)
-				|| in_array('ordercard',$TContext)
-		        || in_array('ordersuppliercard',$TContext)
-				|| in_array('invoicereccard',$TContext)
+				in_array('invoicecard',$contextArray)
+		        || in_array('invoicesuppliercard',$contextArray)
+				|| in_array('propalcard',$contextArray)
+				|| in_array('ordercard',$contextArray)
+		        || in_array('ordersuppliercard',$contextArray)
+				|| in_array('invoicereccard',$contextArray)
 			)
 	        {
 	            $hideInnerLines	= isset( $_SESSION['subtotal_hideInnerLines_'.$parameters['modulepart']][$object->id] ) ?  $_SESSION['subtotal_hideInnerLines_'.$parameters['modulepart']][$object->id] : 0;
@@ -439,12 +439,12 @@ class ActionsSubtotal
 
 
 				if (
-					(in_array('propalcard',$TContext) && !empty($conf->global->SUBTOTAL_PROPAL_ADD_RECAP))
-					|| (in_array('ordercard',$TContext) && !empty($conf->global->SUBTOTAL_COMMANDE_ADD_RECAP))
-				    || (in_array('ordersuppliercard',$TContext) && !empty($conf->global->SUBTOTAL_COMMANDE_ADD_RECAP))
-					|| (in_array('invoicecard',$TContext) && !empty($conf->global->SUBTOTAL_INVOICE_ADD_RECAP))
-				    || (in_array('invoicesuppliercard',$TContext) && !empty($conf->global->SUBTOTAL_INVOICE_ADD_RECAP))
-					|| (in_array('invoicereccard',$TContext)  && !empty($conf->global->SUBTOTAL_INVOICE_ADD_RECAP ))
+					(in_array('propalcard',             $contextArray) && !empty($conf->global->SUBTOTAL_PROPAL_ADD_RECAP))
+					|| (in_array('ordercard',           $contextArray) && !empty($conf->global->SUBTOTAL_COMMANDE_ADD_RECAP))
+				    || (in_array('ordersuppliercard',   $contextArray) && !empty($conf->global->SUBTOTAL_COMMANDE_ADD_RECAP))
+					|| (in_array('invoicecard',         $contextArray) && !empty($conf->global->SUBTOTAL_INVOICE_ADD_RECAP))
+				    || (in_array('invoicesuppliercard', $contextArray) && !empty($conf->global->SUBTOTAL_INVOICE_ADD_RECAP))
+					|| (in_array('invoicereccard',      $contextArray) && !empty($conf->global->SUBTOTAL_INVOICE_ADD_RECAP ))
 				)
 				{
 					$var=!$var;
@@ -528,15 +528,16 @@ class ActionsSubtotal
 	}
 
 	function createFrom($parameters, &$object, $action, $hookmanager) {
-
+		$contextArray = array();
+		if (!empty($parameters['context'])) $contextArray = explode(':', $parameters['context']);
 		if (
-				in_array('invoicecard',explode(':',$parameters['context']))
-		        || in_array('invoicesuppliercard',explode(':',$parameters['context']))
-				|| in_array('propalcard',explode(':',$parameters['context']))
-		        || in_array('supplier_proposalcard',explode(':',$parameters['context']))
-				|| in_array('ordercard',explode(':',$parameters['context']))
-		        || in_array('ordersuppliercard',explode(':',$parameters['context']))
-				|| in_array('invoicereccard',explode(':',$parameters['context']))
+				in_array('invoicecard',              $contextArray)
+		        || in_array('invoicesuppliercard',   $contextArray)
+				|| in_array('propalcard',            $contextArray)
+		        || in_array('supplier_proposalcard', $contextArray)
+				|| in_array('ordercard',             $contextArray)
+		        || in_array('ordersuppliercard',     $contextArray)
+				|| in_array('invoicereccard',        $contextArray)
 		) {
 
 			global $db;
@@ -581,8 +582,8 @@ class ActionsSubtotal
 	function doActions($parameters, &$object, $action, $hookmanager)
 	{
 		global $db, $conf, $langs,$user;
-		$TContext = array();
-		if (isset($parameters['context'])) $TContext = explode(':', $parameters['context']);
+		$contextArray = array();
+		if (isset($parameters['context'])) $contextArray = explode(':', $parameters['context']);
 
 		dol_include_once('/subtotal/class/subtotal.class.php');
 		dol_include_once('/subtotal/lib/subtotal.lib.php');
@@ -625,40 +626,40 @@ class ActionsSubtotal
 		else if($action === 'builddoc') {
 
 			if (
-				in_array('invoicecard',explode(':',$parameters['context']))
-				|| in_array('propalcard',explode(':',$parameters['context']))
-				|| in_array('ordercard',explode(':',$parameters['context']))
-			    || in_array('ordersuppliercard',explode(':',$parameters['context']))
-			    || in_array('invoicesuppliercard',explode(':',$parameters['context']))
-			    || in_array('supplier_proposalcard',explode(':',$parameters['context']))
+				in_array('invoicecard',              $contextArray)
+				|| in_array('propalcard',            $contextArray)
+				|| in_array('ordercard',             $contextArray)
+			    || in_array('ordersuppliercard',     $contextArray)
+			    || in_array('invoicesuppliercard',   $contextArray)
+			    || in_array('supplier_proposalcard', $contextArray)
 			)
 	        {
-				if(in_array('invoicecard',explode(':',$parameters['context']))) {
+				if(in_array('invoicecard',$contextArray)) {
 					$sessname = 'subtotal_hideInnerLines_facture';
 					$sessname2 = 'subtotal_hidedetails_facture';
 					$sessname3 = 'subtotal_hideprices_facture';
 				}
-				elseif(in_array('invoicesuppliercard',explode(':',$parameters['context']))) {
+				elseif(in_array('invoicesuppliercard',$contextArray)) {
 				    $sessname = 'subtotal_hideInnerLines_facture_fournisseur';
 				    $sessname2 = 'subtotal_hidedetails_facture_fournisseur';
 				    $sessname3 = 'subtotal_hideprices_facture_fournisseur';
 				}
-				elseif(in_array('propalcard',explode(':',$parameters['context']))) {
+				elseif(in_array('propalcard',$contextArray)) {
 					$sessname = 'subtotal_hideInnerLines_propal';
 					$sessname2 = 'subtotal_hidedetails_propal';
 					$sessname3 = 'subtotal_hideprices_propal';
 				}
-				elseif(in_array('supplier_proposalcard',explode(':',$parameters['context']))) {
+				elseif(in_array('supplier_proposalcard',$contextArray)) {
 				    $sessname = 'subtotal_hideInnerLines_supplier_proposal';
 				    $sessname2 = 'subtotal_hidedetails_supplier_proposal';
 				    $sessname3 = 'subtotal_hideprices_supplier_proposal';
 				}
-				elseif(in_array('ordercard',explode(':',$parameters['context']))) {
+				elseif(in_array('ordercard',$contextArray)) {
 					$sessname = 'subtotal_hideInnerLines_commande';
 					$sessname2 = 'subtotal_hidedetails_commande';
 					$sessname3 = 'subtotal_hideprices_commande';
 				}
-				elseif(in_array('ordersuppliercard',explode(':',$parameters['context']))) {
+				elseif(in_array('ordersuppliercard',$contextArray)) {
 				    $sessname = 'subtotal_hideInnerLines_commande_fournisseur';
 				    $sessname2 = 'subtotal_hidedetails_commande_fournisseur';
 				    $sessname3 = 'subtotal_hideprices_commande_fournisseur';
@@ -777,9 +778,9 @@ class ActionsSubtotal
 		}
 
 		elseif ((!empty($parameters['currentcontext']) && $parameters['currentcontext'] == 'orderstoinvoice')
-				|| in_array('orderstoinvoice',$TContext)
-				|| in_array('orderstoinvoicesupplier',$TContext)
-				|| in_array('orderlist',$TContext)
+				|| in_array('orderstoinvoice',         $contextArray)
+				|| in_array('orderstoinvoicesupplier', $contextArray)
+				|| in_array('orderlist',               $contextArray)
 		) {
 			$this->_billOrdersAddCheckBoxForTitleBlocks();
 		}

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1653,13 +1653,25 @@ class ActionsSubtotal
 		return $resArray;
 	}
 
-	// TODO ne gère pas encore la numération des lignes "Totaux"
+	/**
+	 * TODO ne gère pas encore la numération des lignes "Totaux"
+	 * @param CommonObjectLine[] $TLineTitle
+	 * @param string             $line_reference
+	 * @param int                $level
+	 * @param int                $prefix_num
+	 * @return array
+	 */
 	private function formatNumerotation(&$TLineTitle, $line_reference='', $level=1, $prefix_num=0)
 	{
 		$TTitle = array();
 
 		$i=1;
 		$j=0;
+		$TLineElementsWithoutLabel = array(
+			// liste de lignes n'utilisant pas le champ `label` mais le champ `description` (`desc`)
+			'facture_fourn_det',
+			'commande_fournisseurdet',
+		);
 		foreach ($TLineTitle as $k => &$line)
 		{
 			if (!empty($line_reference) && $line->rang <= $line_reference->rang) continue;
@@ -1669,8 +1681,10 @@ class ActionsSubtotal
 			{
 				$TTitle[$j]['numerotation'] = ($prefix_num == 0) ? $i : $prefix_num.'.'.$i;
 				//var_dump('Prefix == '.$prefix_num.' // '.$line->desc.' ==> numerotation == '.$TTitle[$j]['numerotation'].'   ###    '.$line->qty .'=='. $level);
-				if (empty($line->label) && (float)DOL_VERSION < 6)
-				{
+				if (empty($line->label) && (
+					(float)DOL_VERSION < 6 || in_array($line->element, $TLineElementsWithoutLabel)
+					)
+				) {
 					$line->label = !empty($line->desc) ? $line->desc : $line->description;
 					$line->desc = $line->description = '';
 				}

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -63,7 +63,7 @@ class modSubtotal extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Module permettant l'ajout de sous-totaux et sous-totaux intermédiaires et le déplacement d'une ligne aisée de l'un dans l'autre";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '3.6.8';
+        $this->version = '3.6.9';
 
         // Key used in llx_const table to save module status enabled/disabled
         // (where MYMODULE is value of property name of module in uppercase)


### PR DESCRIPTION
# FIX
On some document types, title lines are not displayed correctly on PDF documents because the lines of those documents don't use the same fields (`desc` and `label`) in the same way others do.