### PR TITLE
FIX : Compatibilité V15

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 # [Unreleased]
 
 ## Version 3.7
-
+- FIX : Compatibility with version 15 *14/12/2021* - 3.7.1
 - NEW : add api subtotal to module. add entryPoint getTotalLine  *17/11/2021* - 3.7.0
     
 

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -2839,7 +2839,8 @@ class ActionsSubtotal
 
 	}
 
-	function printOriginObjectLine($parameters, &$object, &$action, $hookmanager)
+
+	function printOriginObjectSubLine($parameters, &$object, &$action, $hookmanager)
 	{
 		global $conf,$langs,$user,$db,$bc, $restrictlist, $selectedLines;
 
@@ -2856,8 +2857,10 @@ class ActionsSubtotal
 
 			if(class_exists('TSubtotal')){ dol_include_once('/subtotal/class/subtotal.class.php'); }
 
+
 			if (TSubtotal::isModSubtotalLine($line))
 			{
+
 				$object->tpl['subtotal'] = $line->id;
 				if (TSubtotal::isTitle($line)) $object->tpl['sub-type'] = 'title';
 				else if (TSubtotal::isSubtotal($line)) $object->tpl['sub-type'] = 'total';
@@ -2884,6 +2887,7 @@ class ActionsSubtotal
 					else $object->tpl['sub-tr-style'].= 'background:#eeffee;' ;
 				}
 
+
 				$object->tpl['sub-td-style'] = '';
 				if ($line->qty>90) $object->tpl['sub-td-style'] = 'style="text-align:right"';
 
@@ -2904,7 +2908,6 @@ class ActionsSubtotal
 					if($line->qty<=1) $object->tpl["sublabel"] = img_picto('', 'subtotal@subtotal');
 					else if($line->qty==2) $object->tpl["sublabel"] = img_picto('', 'subsubtotal@subtotal').'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;';
 				}
-
 				// Get display styles and apply them
 				$titleStyleItalic = strpos($conf->global->SUBTOTAL_TITLE_STYLE, 'I') === false ? '' : ' font-style: italic;';
 				$titleStyleBold =  strpos($conf->global->SUBTOTAL_TITLE_STYLE, 'B') === false ? '' : ' font-weight:bold;';
@@ -2930,8 +2933,6 @@ class ActionsSubtotal
 					$object->tpl["sublabel"].= ' : <b>'.$total.'</b>';
 				}
 
-
-
 			}
 
 			$object->printOriginLine($line, '', $restrictlist, '/core/tpl', $selectedLines);
@@ -2943,9 +2944,12 @@ class ActionsSubtotal
 			unset($object->tpl['subtotal']);
 		}
 
-		return 0;
+        return 1;
 	}
 
+    function printOriginLinesList($parameters, &$object, &$action, $hookmanager) {
+        $this->printOriginObjectSubLine($parameters, $object, $action, $hookmanager);
+    }
 
 	function addMoreActionsButtons($parameters, &$object, &$action, $hookmanager) {
 		global $conf,$langs;

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -63,7 +63,7 @@ class modSubtotal extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Module permettant l'ajout de sous-totaux et sous-totaux intermédiaires et le déplacement d'une ligne aisée de l'un dans l'autre";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '3.7.0';
+        $this->version = '3.7.1';
 
         // Key used in llx_const table to save module status enabled/disabled
         // (where MYMODULE is value of property name of module in uppercase)


### PR DESCRIPTION
### FIX : Compatibilité V15

- Changement du nom de la fonction (hook) "printOriginLinesList" en "printOriginObjectSubLine" 
- Rétrocompatibilité : Utilisation de la fonction (hook) "printOriginObjectSubLine"  dans la fonction (hook) "printOriginLinesList"
- Changement de la valeur de retour 0 en 1