### PR TITLE
FIX for createbills_onebythird

### DIFF
--- a/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
+++ b/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
@@ -258,7 +258,7 @@ class Interfacesubtotaltrigger extends DolibarrTriggers
             }
 		    else
             {
-			    $subtotal_add_title_bloc_from_orderstoinvoice = GETPOST('subtotal_add_title_bloc_from_orderstoinvoice', 'none');
+			    $subtotal_add_title_bloc_from_orderstoinvoice = (GETPOST('subtotal_add_title_bloc_from_orderstoinvoice', 'none') || GETPOST('createbills_onebythird', 'int'));
 			    if (!empty($subtotal_add_title_bloc_from_orderstoinvoice))
 			    {
 				    global $subtotal_current_rang, $subtotal_bloc_previous_fk_commande, $subtotal_bloc_already_add_title, $subtotal_bloc_already_add_st;


### PR DESCRIPTION
la facturation des commandes se fait maintenant depuis la liste des commandes via une action de masse.
cette PR permet de prendre en compte cette nouvelle approche pour avoir un titre par commande dans la facture.