### PR TITLE
FIX update info bits on create from hook

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ## Version 3.14 PI 
 
-- FIX : Update info bits on create from hook - *18/11/2022* - 3.14.6
+- FIX : Update info bits on create from hook - *18/11/2022* - 3.14.6  
   le code permettant de mettre à jour l'info bit semble être obsolète depuis la version 10 de Dolibarr (le mieux serait de remonter sur les versions précédentes et retrouver à partir de quelle version de Dolibarr ce code n'est plus utile)
   De plus, il ajoute des sauts de lignes lorsque l'objet copié et l'objet source ne possèdent pas le même nombre de lignes. En effet un autre module peut ajouter une ligne et on a alors un saut de ligne supplémentaire.
 - FIX : PHP 8 Compatibility - *13/07/2022* - 3.14.5

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 
 ## Version 3.14 PI 
 
+- FIX : Update info bits on create from hook - *18/11/2022* - 3.14.6
+  le code permettant de mettre à jour l'info bit semble être obsolète depuis la version 10 de Dolibarr (le mieux serait de remonter sur les versions précédentes et retrouver à partir de quelle version de Dolibarr ce code n'est plus utile)
+  De plus, il ajoute des sauts de lignes lorsque l'objet copié et l'objet source ne possèdent pas le même nombre de lignes. En effet un autre module peut ajouter une ligne et on a alors un saut de ligne supplémentaire.
 - FIX : PHP 8 Compatibility - *13/07/2022* - 3.14.5
 - FIX : Admin déplacement de l'option de récap en zone expérimentale *11/07/2022* 3.14.4
 - FIX : html tag missing for style *11/07/2022* 3.14.3

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ## Version 3.14 PI 
 
-- FIX : Update info bits on create from hook - *18/11/2022* - 3.14.6  
+- FIX : Update info bits on create from hook - *18/11/2022* - 3.14.6 ```PR #273 OpenDsi```  
   le code permettant de mettre à jour l'info bit semble être obsolète depuis la version 10 de Dolibarr (le mieux serait de remonter sur les versions précédentes et retrouver à partir de quelle version de Dolibarr ce code n'est plus utile)
   De plus, il ajoute des sauts de lignes lorsque l'objet copié et l'objet source ne possèdent pas le même nombre de lignes. En effet un autre module peut ajouter une ligne et on a alors un saut de ligne supplémentaire.
 - FIX : PHP 8 Compatibility - *13/07/2022* - 3.14.5

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -562,6 +562,11 @@ class ActionsSubtotal
 	}
 
 	function createFrom($parameters, &$object, $action, $hookmanager) {
+
+        if (version_compare(DOL_VERSION, '10.0.0') >= 0) {
+            return 0;
+        }
+
 		$contextArray = array();
 		if (!empty($parameters['context'])) $contextArray = explode(':', $parameters['context']);
 		if (

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -563,7 +563,7 @@ class ActionsSubtotal
 
 	function createFrom($parameters, &$object, $action, $hookmanager) {
 
-        if (version_compare(DOL_VERSION, '10.0.0') >= 0) {
+        if (version_compare(DOL_VERSION, '10.0.0', '>=')) {
             return 0;
         }
 

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -66,7 +66,7 @@ class modSubtotal extends DolibarrModules
         $this->description = "Module permettant l'ajout de sous-totaux et sous-totaux intermédiaires et le déplacement d'une ligne aisée de l'un dans l'autre";
         // Possible values for version are: 'development', 'experimental' or version
 
-        $this->version = '3.14.5';
+        $this->version = '3.14.6';
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \subtotal\TechATM::getLastModuleVersionUrl($this);


### PR DESCRIPTION
FIX update info bits on create from hook
- le code permettant de mettre à jour l'info bit semble être obsolète depuis la version 10 de Dolibarr (le mieux serait de remonter sur les versions précédentes et retrouver à partir de quelle version de Dolibarr ce code n'est plus utile)

De plus, il ajoute des sauts de lignes lorsque l'objet copié et l'objet source ne possèdent pas le même nombre de lignes. En effet un autre module peut ajouter une ligne et on a alors un saut de ligne supplémentaire.