### PR TITLE
fix: remove dolibarr error log "Error: Bug into hook defineColumnField of module class ActionsSubtotal. Method must not return a string but an int (0=OK, 1=Replace, -1=KO) and set string into ->resprints"

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -3664,6 +3664,7 @@ class ActionsSubtotal
 		$parameters['object']->subtotalPdfModelInfo->defaultTitlesFieldsStyle = $pdfDoc->subtotalPdfModelInfo->defaultTitlesFieldsStyle;
 		$parameters['object']->subtotalPdfModelInfo->defaultContentsFieldsStyle = $pdfDoc->subtotalPdfModelInfo->defaultContentsFieldsStyle;
 
+		return 0;
 	}
 
 	/**


### PR DESCRIPTION
fix: remove dolibarr error log "Error: Bug into hook defineColumnField of module class ActionsSubtotal. Method must not return a string but an int (0=OK, 1=Replace, -1=KO) and set string into ->resprints"