### PR TITLE
Fix : remove_transaction_in_pdf_writelinedesc

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## Version 3.14 PI 
-
+- FIX : Remove transaction in  pdf_writelinedesc *10/11/2022* - 3.14.6 
 - FIX : PHP 8 Compatibility - *13/07/2022* - 3.14.5
 - FIX : Admin déplacement de l'option de récap en zone expérimentale *11/07/2022* 3.14.4
 - FIX : html tag missing for style *11/07/2022* 3.14.3

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -2170,7 +2170,6 @@ class ActionsSubtotal
 		if($this->isModSubtotalLine($parameters,$object) ){
 
 				global $hideprices;
-
 				if(!empty($hideprices)) {
 					foreach($object->lines as &$line) {
 						if($line->fk_product_type!=9) $line->fk_parent_line = -1;
@@ -2199,26 +2198,50 @@ class ActionsSubtotal
 					if (!empty($conf->global->CONCAT_TITLE_LABEL_IN_SUBTOTAL_LABEL)) {
                         $label .= ' '.$this->getTitle($object, $line);
                     }
+					/**
+					 * https://github.com/ATM-Consulting/dolibarr_module_subtotal/pull/271
+					 * cette pr fait suite à un bug chez Le client SECP
+					 * le bug qu'il corrige n'a pas etait reproduit par quentin avec les même informations
+					 * chez le client. il faudra voir avec le client si le problème revient.
+					 *
+					 * Suite à un bug rencontré avec plusieurs clients suite à la PR ci-dessus
+					 * il a était convenu de commenter  les transactions  dans cette partie du code
+					 * TCPDF ne gère pas les transactions dans des trasactions.
+					 *
+					 */
+                   // $pdf->startTransaction();
 
-                    $pdf->startTransaction();
-					$pageBefore = $pdf->getPage();
+				   // $pageBefore = $pdf->getPage();
 					$this->pdf_add_total($pdf,$object, $line, $label, $description,$posx, $posy, $w, $h);
-					$pageAfter = $pdf->getPage();
-
-					if($pageAfter>$pageBefore) {
+				   // $pageAfter = $pdf->getPage();
+					/**
+					 * https://github.com/ATM-Consulting/dolibarr_module_subtotal/pull/271
+					 * cette pr fait suite à un bug chez Le client SECP
+					 * le bug qu'il corrige n'a pas etait reproduit par quentin avec les même informations
+					 * chez le client. il faudra voir avec le client si le problème revient.
+					 *
+					 * Suite à un bug rencontré avec plusieurs clients suite à la PR ci-dessus
+					 * il a était convenu de commenter  les transactions  dans cette partie du code
+					 * TCPDF ne gère pas les transactions dans des trasactions.
+					 *
+					 */
+					 //
+					/*if($pageAfter>$pageBefore) {
 						//print "ST $pageAfter>$pageBefore<br>";
-						$pdf->rollbackTransaction(true);
+						//$pdf->rollbackTransaction(true);
 						$pdf->addPage('', '', true);
 						$posy = $pdf->GetY();
 						$this->pdf_add_total($pdf, $object, $line, $label, $description, $posx, $posy, $w, $h);
 						$posy = $pdf->GetY();
 						//print 'add ST'.$pdf->getPage().'<br />';
+
 					}
                     else	// No pagebreak
                     {
                         $pdf->commitTransaction();
-                    }
-
+                    }*/
+					// FIN REMOVE
+					//
 					// On delivery PDF, we don't want quantities to appear and there are no hooks => setting text color to background color;
 					if($object->element == 'delivery')
 					{
@@ -2243,26 +2266,49 @@ class ActionsSubtotal
 					return 1;
 				}
 				else if ($line->qty < 10) {
+					/**
+					 * https://github.com/ATM-Consulting/dolibarr_module_subtotal/pull/271
+					 * cette pr fait suite à un bug chez Le client SECP
+					 * le bug qu'il corrige n'a pas etait reproduit par quentin avec les même informations
+					 * chez le client. il faudra voir avec le client si le problème revient.
+					 *
+					 * Suite à un bug rencontré avec plusieurs clients suite à la PR ci-dessus
+					 * il a était convenu de commenter  les transactions  dans cette partie du code
+					 * TCPDF ne gère pas les transactions dans des trasactions.
+					 *
+					 */
+                    //$pdf->startTransaction();
 
-                    $pdf->startTransaction();
-					$pageBefore = $pdf->getPage();
+					//$pageBefore = $pdf->getPage();
 					$this->pdf_add_title($pdf,$object, $line, $label, $description,$posx, $posy, $w, $h);
-					$pageAfter = $pdf->getPage();
+					//$pageAfter = $pdf->getPage();
 
-                    if($pageAfter>$pageBefore) {
+					/**
+					 * https://github.com/ATM-Consulting/dolibarr_module_subtotal/pull/271
+					 * cette pr fait suite à un bug chez Le client SECP
+					 * le bug qu'il corrige n'a pas etait reproduit par quentin avec les même informations
+					 * chez le client. il faudra voir avec le client si le problème revient.
+					 *
+					 * Suite à un bug rencontré avec plusieurs clients suite à la PR ci-dessus
+					 * il a était convenu de commenter  les transactions  dans cette partie du code
+					 * TCPDF ne gère pas les transactions dans des trasactions.
+					 *
+					 */
+                    /*if($pageAfter>$pageBefore) {
                         //print "ST $pageAfter>$pageBefore<br>";
-                        $pdf->rollbackTransaction(true);
+                       // $pdf->rollbackTransaction(true);
                         $pdf->addPage('', '', true);
                         $posy = $pdf->GetY();
                         $this->pdf_add_title($pdf,$object, $line, $label, $description,$posx, $posy, $w, $h);
                         $posy = $pdf->GetY();
                         //print 'add ST'.$pdf->getPage().'<br />';
+
                     }
                     else    // No pagebreak
                     {
                         $pdf->commitTransaction();
-                    }
-
+                    }*/
+					// FIN REMOVE
 
 					if($object->element == 'delivery')
 					{
@@ -2276,13 +2322,34 @@ class ActionsSubtotal
 					$labelproductservice = pdf_getlinedesc($object, $i, $outputlangs, $parameters['hideref'], $parameters['hidedesc'], $parameters['issupplierline']);
 
 					$labelproductservice = preg_replace('/(<img[^>]*src=")([^"]*)(&amp;)([^"]*")/', '\1\2&\4', $labelproductservice, -1, $nbrep);
-
-                    $pdf->startTransaction();
-                    $pageBefore = $pdf->getPage();
+					/**
+					 * https://github.com/ATM-Consulting/dolibarr_module_subtotal/pull/271
+					 * cette pr fait suite à un bug chez Le client SECP
+					 * le bug qu'il corrige n'a pas etait reproduit par quentin avec les même informations
+					 * chez le client. il faudra voir avec le client si le problème revient.
+					 *
+					 * Suite à un bug rencontré avec plusieurs clients suite à la PR ci-dessus
+					 * il a était convenu de commenter  les transactions  dans cette partie du code
+					 * TCPDF ne gère pas les transactions dans des trasactions.
+					 *
+					 */
+                   // $pdf->startTransaction();
+                    //$pageBefore = $pdf->getPage();
                     $pdf->writeHTMLCell($parameters['w'], $parameters['h'], $parameters['posx'], $posy, $outputlangs->convToOutputCharset($labelproductservice), 0, 1, false, true, 'J', true);
-                    $pageAfter = $pdf->getPage();
+                    //$pageAfter = $pdf->getPage();
 
-                    if($pageAfter>$pageBefore) {
+					/**
+					 * https://github.com/ATM-Consulting/dolibarr_module_subtotal/pull/271
+					 * cette pr fait suite à un bug chez Le client SECP
+					 * le bug qu'il corrige n'a pas etait reproduit par quentin avec les même informations
+					 * chez le client. il faudra voir avec le client si le problème revient.
+					 *
+					 * Suite à un bug rencontré avec plusieurs clients suite à la PR ci-dessus
+					 * il a était convenu de commenter  les transactions  dans cette partie du code
+					 * TCPDF ne gère pas les transactions dans des trasactions.
+					 *
+					 */
+                    /*if($pageAfter>$pageBefore) {
                         //print "ST $pageAfter>$pageBefore<br>";
                         $pdf->rollbackTransaction(true);
                         $pdf->addPage('', '', true);
@@ -2295,7 +2362,7 @@ class ActionsSubtotal
                     else    // No pagebreak
                     {
                         $pdf->commitTransaction();
-                    }
+                    }*/
 
 					return 1;
 				}

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -66,7 +66,7 @@ class modSubtotal extends DolibarrModules
         $this->description = "Module permettant l'ajout de sous-totaux et sous-totaux intermédiaires et le déplacement d'une ligne aisée de l'un dans l'autre";
         // Possible values for version are: 'development', 'experimental' or version
 
-        $this->version = '3.14.5';
+        $this->version = '3.14.6';
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \subtotal\TechATM::getLastModuleVersionUrl($this);


### PR DESCRIPTION
* https://github.com/ATM-Consulting/dolibarr_module_subtotal/pull/271
* cette pr fait suite à un bug chez Le client SECP
* le bug qu'il corrige n'a pas etait reproduit par quentin avec les même informations
* chez le client. il faudra voir avec le client si le problème revient. *
* Suite à un bug rencontré avec plusieurs clients suite à la PR ci-dessus
* il a était convenu de commenter  les transactions  dans cette partie du code
* TCPDF ne gère pas les transactions dans des trasactions. *
*/
add version control