### PR TITLE
FIX [DA022658] : Gestion des non-compris non-fonctionnelle

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## Version 3.15
-
+- FIX : DA022658 - Gestion des non-compris non-fonctionnelle - 3.15.2
 - FIX : Fatal error *02/01/2023* - 3.15.1
 - NEW : Ajout de massaction de suppression de ligne sur les card *16/11/2022* 3.15.0
 

--- a/admin/subtotal_setup.php
+++ b/admin/subtotal_setup.php
@@ -179,7 +179,12 @@ $item->fieldOutputOverride ='<input type="color" value="'.$item->fieldValue .'" 
 // Activer la gestion des blocs "Non Compris" pour exclusion du total
 $formSetup->newItem('ManageNonCompris')->setAsTitle();
 
-$formSetup->newItem('SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS')->setAsYesNo();
+$itemNC = $formSetup->newItem('SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS')->setAsSelect(array(0 => $langs->transnoentities('No'), 1 => $langs->transnoentities('Yes')));
+$itemNC->setSaveCallBack(function ($itemNC){
+	if((int) $itemNC->fieldValue > 0) {
+		_createExtraComprisNonCompris();
+	}
+});
 
 
 // Colonnes à afficher sur lignes marquées "Non Compris"
@@ -321,6 +326,7 @@ $formSetup->newItem('SUBTOTAL_PROPAL_ADD_RECAP')->setAsYesNo();
 
 if ($action == 'update' && !empty($formSetup) && is_object($formSetup) && !empty($user->admin)) {
 	$formSetup->saveConfFromPost();
+	$result = dolibarr_set_const($itemNC->db, $itemNC->confKey, $itemNC->fieldValue, 'chaine', 0, '', $itemNC->entity);
 	header('Location:'.$_SERVER['PHP_SELF']);
 	exit;
 }

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -67,7 +67,7 @@ class modSubtotal extends DolibarrModules
         // Possible values for version are: 'development', 'experimental' or version
 
 
-        $this->version = '3.15.1';
+        $this->version = '3.15.2';
 
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';

--- a/lib/subtotal.lib.php
+++ b/lib/subtotal.lib.php
@@ -356,7 +356,7 @@ function doUpdate(&$object, &$line, $subtotal_nc, $notrigger = 0)
 	// Update extrafield et total
 	if(! empty($subtotal_nc)) {
 		$line->total_ht = $line->total_tva = $line->total_ttc = $line->total_localtax1 = $line->total_localtax2 =
-			$line->multicurrency_total_ht = $line->multicurrency_total_tva = $line->multicurrency_total_ttc = 0;
+			$line->multicurrency_total_ht = $line->multicurrency_total_tva = $line->multicurrency_total_ttc = $line->remise = 0;
 		if(!empty($conf->global->SUBTOTAL_NONCOMPRIS_UPDATE_PA_HT)) $line->pa_ht = '0';
 
 		$line->array_options['options_subtotal_nc'] = 1;


### PR DESCRIPTION
### FIX [DA022658] : Gestion des non-compris non-fonctionnelle

La gestion des lignes non-comprises n'était pas fonctionnelle. En effet, pour que cela fonctionne correctement, il est nécessaire que certains extrafields soient crées à l'activation de la configuration de gestion des lignes non-comprises. Or ces derniers n'étaient pas crées.
- Modification du type de conf pour pouvoir procéder à un callback 
- Appel de la fonction de création des extrafields 
- Enregistrement de la conf lors de l'update (car le callback empêche son enregistrement standard)

- Passage de la valeur de remise à 0 (car champ déprécié qui pourrait poser soucis dans certains cas).