### PR TITLE
FIX : DA022849 - COMPAT V17

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## Version 3.15
+- FIX : Multiples erreurs de colspan qui créaient des décalage sur les tableaux de lignes - *20/01/2023* - 3.15.3
 - FIX : DA022658 - Gestion des non-compris non-fonctionnelle - 3.15.2
 - FIX : Fatal error *02/01/2023* - 3.15.1
 - NEW : Ajout de massaction de suppression de ligne sur les card *16/11/2022* 3.15.0

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -2520,6 +2520,7 @@ class ActionsSubtotal
 			}
 			if(empty($line->description)) $line->description = $line->desc;
 			$colspan = 5;
+			if(DOL_VERSION > 16.0) $colspan++; // Ajout de la colonne PU TTC
 			if($object->element == 'facturerec' ) $colspan = 3;
 			if($object->element == 'order_supplier') (float) DOL_VERSION < 7.0 ? $colspan = 3 : $colspan = 6;
 			if($object->element == 'invoice_supplier') (float) DOL_VERSION < 7.0 ? $colspan = 4: $colspan = 7;
@@ -2536,7 +2537,6 @@ class ActionsSubtotal
 			if(!empty($conf->global->PRODUCT_USE_UNITS)) $colspan++;
 			// Compatibility module showprice
 			if(!empty($conf->showprice->enabled)) $colspan++;
-
 			/* Titre */
 			//var_dump($line);
 

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -2518,21 +2518,28 @@ class ActionsSubtotal
 				</script>
 				<?php
 			}
+
 			if(empty($line->description)) $line->description = $line->desc;
+
+            $TNonAffectedByMarge = array('order_supplier', 'invoice_supplier', 'supplier_proposal');
+            $affectedByMarge = in_array($object->element, $TNonAffectedByMarge) ? 0 : 1;
 			$colspan = 5;
-			if(DOL_VERSION > 16.0) $colspan++; // Ajout de la colonne PU TTC
-			if($object->element == 'facturerec' ) $colspan = 3;
 			if($object->element == 'order_supplier') (float) DOL_VERSION < 7.0 ? $colspan = 3 : $colspan = 6;
 			if($object->element == 'invoice_supplier') (float) DOL_VERSION < 7.0 ? $colspan = 4: $colspan = 7;
 			if($object->element == 'supplier_proposal') (float) DOL_VERSION < 6.0 ? $colspan = 4 : $colspan = 3;
+
+			if(DOL_VERSION > 16.0) $colspan++; // Ajout de la colonne PU TTC
+
+			if($object->element == 'facturerec' ) $colspan = 5;
+
 			if(!empty($conf->multicurrency->enabled) && ((float) DOL_VERSION < 8.0 || $object->multicurrency_code != $conf->currency)) {
 				$colspan++; // Colonne PU Devise
 			}
 			if($object->element == 'commande' && $object->statut < 3 && !empty($conf->shippableorder->enabled)) $colspan++;
 			$margins_hidden_by_module = empty($conf->affmarges->enabled) ? false : !($_SESSION['marginsdisplayed']);
 			if(!empty($conf->margin->enabled) && !$margins_hidden_by_module) $colspan++;
-			if(!empty($conf->margin->enabled) && !empty($conf->global->DISPLAY_MARGIN_RATES) && !$margins_hidden_by_module) $colspan++;
-			if(!empty($conf->margin->enabled) && !empty($conf->global->DISPLAY_MARK_RATES) && !$margins_hidden_by_module) $colspan++;
+			if(!empty($conf->margin->enabled) && !empty($conf->global->DISPLAY_MARGIN_RATES) && !$margins_hidden_by_module && $affectedByMarge > 0) $colspan++;
+			if(!empty($conf->margin->enabled) && !empty($conf->global->DISPLAY_MARK_RATES) && !$margins_hidden_by_module && $affectedByMarge > 0) $colspan++;
 			if($object->element == 'facture' && !empty($conf->global->INVOICE_USE_SITUATION) && $object->type == Facture::TYPE_SITUATION) $colspan++;
 			if(!empty($conf->global->PRODUCT_USE_UNITS)) $colspan++;
 			// Compatibility module showprice

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -67,7 +67,7 @@ class modSubtotal extends DolibarrModules
         // Possible values for version are: 'development', 'experimental' or version
 
 
-        $this->version = '3.15.2';
+        $this->version = '3.15.3';
 
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';


### PR DESCRIPTION
## FIX : DA022849 - COMPAT V17

Quelques erreurs de colspan étaient présentes sur les tableaux de lignes : 
- Colspan manquant pour la majorité des objets (dû à l'ajoute de la colonne PU TTC dans l'affichage standard 
- Mauvaise gestion des colspan ajoutés par les marges : 
     Création d'un tableau pour les élément ne prenant pas en compte les marges, on n'augmente le colspan que si l'élément courant affiche les marge dans son tableau de ligne