### PR TITLE
FIX: subtotal rounding was forced to 1 decimal

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -575,9 +575,9 @@ class ActionsSubtotal
 					//list($total, $total_tva, $total_ttc, $TTotal_tva) = $this->getTotalLineFromObject($object, $line, '', 1);
 					$TInfo = $this->getTotalLineFromObject($object, $line, '', 1);
 
-					$substitutionarray['line_price_ht'] = price($TInfo[0],0,'',1,$conf->global->MAIN_MAX_DECIMALS_TOT,1);
-					$substitutionarray['line_price_vat'] = price($TInfo[1],0,'',1,$conf->global->MAIN_MAX_DECIMALS_TOT,1);
-					$substitutionarray['line_price_ttc'] = price($TInfo[2],0,'',1,$conf->global->MAIN_MAX_DECIMALS_TOT,1);
+					$substitutionarray['line_price_ht'] = price($TInfo[0],0,'',1,0,$conf->global->MAIN_MAX_DECIMALS_TOT);
+					$substitutionarray['line_price_vat'] = price($TInfo[1],0,'',1,0,$conf->global->MAIN_MAX_DECIMALS_TOT);
+					$substitutionarray['line_price_ttc'] = price($TInfo[2],0,'',1,0,$conf->global->MAIN_MAX_DECIMALS_TOT);
 				} else {
 					$substitutionarray['line_modsubtotal_title'] = true;
 				}
@@ -1241,7 +1241,7 @@ class ActionsSubtotal
 		}
 
 		if (!$hidePriceOnSubtotalLines) {
-			$total_to_print = price($line->total,0,'',1,$conf->global->MAIN_MAX_DECIMALS_TOT,1);
+			$total_to_print = price($line->total,0,'',1,0,$conf->global->MAIN_MAX_DECIMALS_TOT);
 			if (!empty($conf->global->SUBTOTAL_MANAGE_COMPRIS_NONCOMPRIS))
 			{
 				$TTitle = TSubtotal::getAllTitleFromLine($line);
@@ -1272,7 +1272,7 @@ class ActionsSubtotal
 
 					$TInfo = $this->getTotalLineFromObject($object, $line, '', 1);
 					$TTotal_tva = $TInfo[3];
-					$total_to_print = price($TInfo[0],0,'',1,$conf->global->MAIN_MAX_DECIMALS_TOT,1);
+					$total_to_print = price($TInfo[0],0,'',1,0,$conf->global->MAIN_MAX_DECIMALS_TOT);
 
                     $line->total_ht = $TInfo[0];
 					$line->total = $TInfo[0];
@@ -1588,7 +1588,7 @@ class ActionsSubtotal
 			}
 		}
 		if (GETPOST('hideInnerLines', 'int') && !empty($conf->global->SUBTOTAL_REPLACE_WITH_VAT_IF_HIDE_INNERLINES)){
-		    $this->resprints = price($object->lines[$i]->total_ht,0,'',1,$conf->global->MAIN_MAX_DECIMALS_TOT,1);
+		    $this->resprints = price($object->lines[$i]->total_ht,0,'',1,0,$conf->global->MAIN_MAX_DECIMALS_TOT);
 		}
 
 		// Si la gestion C/NC est active et que je suis sur un ligne dont l'extrafield est coché
@@ -1734,7 +1734,7 @@ class ActionsSubtotal
                 if(is_object($parentTitle) && empty($parentTitle->array_options)) $parentTitle->fetch_optionals();
                 if(! empty($parentTitle->array_options['options_show_total_ht'])) {
                     $TTotal = TSubtotal::getTotalBlockFromTitle($object, $parentTitle);
-                    $this->resprints = price($TTotal['total_unit_subprice'],0,'',1,$conf->global->MAIN_MAX_DECIMALS_TOT,1);
+                    $this->resprints = price($TTotal['total_unit_subprice'],0,'',1,0,$conf->global->MAIN_MAX_DECIMALS_TOT);
                 }
             }
 


### PR DESCRIPTION
The `$forcerounding` param of `price()` is not a 0/1 switch, it represents the number of decimals to be forced.

Regression from #317 