### PR TITLE
FIX Display of subtotal with tax on PDF's

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 # [Unreleased]
-
+- FIX : Display subtotal with tax when global PDF_PROPAL_SHOW_PRICE_INCL_TAX is enable
 
 
 # Release 3.23 - 18/12/2023

--- a/admin/subtotal_setup.php
+++ b/admin/subtotal_setup.php
@@ -227,6 +227,7 @@ $TField = array(
 	'pdf_getlinevatrate' => $langs->trans('VAT'),
 	'pdf_getlineupexcltax' => $langs->trans('PriceUHT'),
 	'pdf_getlinetotalexcltax' => $langs->trans('TotalHT'),
+	'pdf_getlinetotalincltax' => $langs->trans('TotalTTC'),
 	'pdf_getlineunit' => $langs->trans('Unit'),
 	'pdf_getlineremisepercent' => $langs->trans('Discount')
 );

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1178,6 +1178,13 @@ class ActionsSubtotal extends \subtotal\RetroCompatCommonHookActions
 			if(isset($staticPdfModel->cols['totalexcltax']['content']['padding'][2])){
 				$subtotalDefaultBottomPadding = $staticPdfModel->cols['totalexcltax']['content']['padding'][0];
 			}
+
+			if(isset($staticPdfModel->cols['totalincltax']['content']['padding'][0])){
+				$subtotalDefaultTopPadding = $staticPdfModel->cols['totalincltax']['content']['padding'][0];
+			}
+			if(isset($staticPdfModel->cols['totalincltax']['content']['padding'][2])){
+				$subtotalDefaultBottomPadding = $staticPdfModel->cols['totalincltax']['content']['padding'][0];
+			}
 		}
 
 
@@ -1308,6 +1315,10 @@ class ActionsSubtotal extends \subtotal\RetroCompatCommonHookActions
 
 			if($pdfModelUseColSystem){
 				$staticPdfModel->printStdColumnContent($pdf, $posy, 'totalexcltax', $total_to_print);
+				if(!empty($conf->global->PDF_PROPAL_SHOW_PRICE_INCL_TAX))
+				{
+					$staticPdfModel->printStdColumnContent($pdf, $posy, 'totalincltax', price($line->total_ttc,0,'',1,0,getDolGlobalInt('MAIN_MAX_DECIMALS_TOT')));
+				}
 			}
 			else{
 				$pdf->MultiCell($pdf->page_largeur-$pdf->marge_droite-$pdf->postotalht, 3, $total_to_print, 0, 'R', 0);


### PR DESCRIPTION
Bonjour,

Je ne sais pas si vous acceptez les contributions extérieures mais comme rien ne m'en empêche, je me permet.
Voici un petit fix qui permet que le sous-total TTC s'affiche correctement lorsque la colonne TTC est activée.

(quand $conf->global->PDF_PROPAL_SHOW_PRICE_INCL_TAX est set)

(testé sur 18.0.3 et 18.0.4)

Bien Cordialement,
Finta Ionut