### PR TITLE
Fix : 

### DIFF
--- a/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
+++ b/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
@@ -276,7 +276,7 @@ class Interfacesubtotaltrigger extends DolibarrTriggers
             }
 		    else
             {
-			    $subtotal_add_title_bloc_from_orderstoinvoice = (GETPOST('subtotal_add_title_bloc_from_orderstoinvoice', 'none') || GETPOST('createbills_onebythird', 'int'));
+			    $subtotal_add_title_bloc_from_orderstoinvoice = (GETPOST('subtotal_add_title_bloc_from_orderstoinvoice', 'none') && GETPOST('createbills_onebythird', 'int'));
 			    if (!empty($subtotal_add_title_bloc_from_orderstoinvoice))
 			    {
 				    global $subtotal_current_rang, $subtotal_bloc_previous_fk_commande, $subtotal_bloc_already_add_title, $subtotal_bloc_already_add_st;


### PR DESCRIPTION
Quand Subtotal est installé avec Factory, on rencontre le bug suivant : 

## Comportement fautif

Quand on est sur la liste des commandes fournisseurs et qu'on fait l'action de masse "facturer les commandes" en regroupant les factures par fournisseur, des lignes de sous-total sont ajoutées sans être voulues (ici la ligne de titre : indique une seule commande pour une facture qui regroupe deux commandes d'une ligne chacune).

![Capture d’écran_2024-01-16_16-10-38](https://github.com/SylvainLegrand/subtotal/assets/89838020/fb158be8-44e9-4e85-b937-96d97d411a83)

Observé sur un DLB14, Subtotal 3.23.6 - InfraS (mais l'erreur est présente sur la version ATM également), Factory 7.0+1.0.45

## Comportement attendu : 

aucune ligne de sous-total n'est ajoutée lors de la génératin de factures par massaction.

_____

Par ailleurs:

- la ligne modifiée ici me semble du code quasi-mort dans la mesure où je ne vois pas appraître la checkbox `subtotal_add_title_bloc_from_orderstoinvoice`...

- même si ce n'est pas du code mort, le sens du `&&` est correct là où le `||` est faux : on veut avoir les lignes si on regroupe les facture (par tiers) ET que la `subtotal_add_title_bloc_from_orderstoinvoice` est cochée. Si on ne regroupe pas les commandes, il n'y a aucune raison de vouloir mettre des totaux intermédiaires.


