### PR TITLE
FIX Include module_number in supplier invoices lines added by the module.

### DIFF
--- a/class/subtotal.class.php
+++ b/class/subtotal.class.php
@@ -133,7 +133,7 @@ class TSubtotal {
                 /** @var FactureFournisseur $object */
 			    $object->special_code = TSubtotal::$module_number;
                 if( (float)DOL_VERSION < 6 ) $rang = $object->line_max() + 1;
-			    $res = $object->addline($label,0,0,0,0,$qty,0,0,'','',0,0,'HT',9,$rang);
+			    $res = $object->addline($label,0,0,0,0,$qty,0,0,'','',0,0,'HT',9,$rang,false,0,null,0,0,'',TSubtotal::$module_number);
 			}
 			/**
 			 * @var $object Propal


### PR DESCRIPTION
This change declare the `module_number` in supplier invoices lines added via the module and fix the view of those lines for supplier invoices in `card.php`.

### Screenshots

#### Before fix

![before](https://github.com/ATM-Consulting/dolibarr_module_subtotal/assets/613615/e1a2f201-8c52-4d2f-ba3c-d1badc7a76cd)

#### After fix

![after](https://github.com/ATM-Consulting/dolibarr_module_subtotal/assets/613615/7daf64ef-1cba-411f-a660-ac4711d23bd6)