### PR TITLE
Update actions_subtotal.class.php

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -2252,6 +2252,10 @@ class ActionsSubtotal extends \subtotal\RetroCompatCommonHookActions
 
 				if ($hideInnerLines)
 				{
+						$hasParentTitle = TSubtotal::getParentTitleOfLine($object, $line->rang);
+						if (empty($hasParentTitle) && empty(TSubtotal::isModSubtotalLine($line))) {	// cette ligne n'est pas dans un titre => on l'affiche
+							$TLines[] = $line;
+						}
 				    if(getDolGlobalString('SUBTOTAL_REPLACE_WITH_VAT_IF_HIDE_INNERLINES'))
 				    {
 				        if($line->tva_tx != '0.000' && $line->product_type!=9){


### PR DESCRIPTION
Made at devcamp, seen with John.

When you use the "hide inner lines" option, all rows are hidden even if they are not included in a title (and subtotal) block.

This PR fix it.