### PR TITLE
bug sur cmdes fournisseur en v18

### DIFF
--- a/class/subtotal.class.php
+++ b/class/subtotal.class.php
@@ -160,6 +160,7 @@ class TSubtotal {
 			 * @var $object Commande fournisseur
 			 */
 			else if($object->element=='order_supplier') {
+			    $object->special_code = TSubtotal::$module_number; // pas logique mais encore necessaire en v18
 			    $res = $object->addline($label, 0,$qty,0,0,0,0,0,'',0,'HT', 0, 9, 0, false, null, null, 0, null, 0, '', 0, -1, TSubtotal::$module_number);
 			}
 			/**


### PR DESCRIPTION
il y a une regression au moins au niveau des commandes fournisseur, avec Dolibarr 18.04 : le special code "104777" n'est enregistré pour aucune des lignes spéciales (titre, sous-total, texte), du coup la ligne ne s'affiche pas correctement

la ligne

$object->special_code = TSubtotal::$module_number;

a été retiré pour les "order_supplier' dans la methode addSubTotalLine de la classe subtotal.class.php

A regarder le code, cela est dû à une lacune du coeur de Dolibarr qui a été corrigée dans des versions plus récentes mais pas dans la 18.04