### PR TITLE
FIX : DA024845

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 
 # Release 3.24 - 08/04/2024
+- FIX : DA024845 : Le module sous total amène des erreurs dans les sauts de page lorsque l'on arrive tout juste en bas de page. - *24/07/2024* - 3.24.5
 - FIX : Module_number missed in subTotal class. function  addSubTotalLine function  in test order_supplier - *26/06/2024* - 3.24.4  
 - FIX : display totalht ligne 'non compris' - *12/04/2024* - 3.24.3  
 - FIX : Title extrafields wasn't working - *12/04/2024* - 3.24.2  

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -2408,6 +2408,15 @@ class ActionsSubtotal extends \subtotal\RetroCompatCommonHookActions
 						$pageBefore = $pdf->getPage();
 					}
 
+
+					// FIX DA024845 : Le module sous total amène des erreurs dans les sauts de page lorsque l'on arrive tout juste en bas de page.
+					$heightForFooter = getDolGlobalInt('MAIN_PDF_MARGIN_BOTTOM', 10) + (getDolGlobalInt('MAIN_GENERATE_DOCUMENTS_SHOW_FOOT_DETAILS') ? 12 : 22); // Height reserved to output the footer (value include bottom margin)
+					if($pdf->getPageHeight() - $posy - $heightForFooter < 8){
+						$pdf->addPage('', '', true);
+						$posy = $pdf->GetY();
+					}
+
+
 					$this->pdf_add_total($pdf,$object, $line, $label, $description,$posx, $posy, $w, $h);
 
 					if(!empty(getDolGlobalString('SUBTOTAL_DISABLE_FIX_TRANSACTION'))) {

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -67,7 +67,7 @@ class modSubtotal extends DolibarrModules
         // Possible values for version are: 'development', 'experimental' or version
 
 
-        $this->version = '3.24.4';
+        $this->version = '3.24.5';
 
 
 		// Url to the file with your last numberversion of this module


### PR DESCRIPTION

Le module sous total amène des erreurs dans les saut de page lorsque l'on arrive tout juste en bas de page. Testé sur une version 3.24.2 de sous total et v18 & V19 de Dolibarr. 