### PR TITLE
FIX(supplier): order and invoice subtotal lines

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 # [Unreleased]
 
+- FIX(supplier): order and invoice subtotal lines
 
 
 # Release 3.25 - 24/07/2024

--- a/class/subtotal.class.php
+++ b/class/subtotal.class.php
@@ -141,7 +141,11 @@ class TSubtotal {
                 /** @var FactureFournisseur $object */
 			    $object->special_code = TSubtotal::$module_number;
                 if( (float)DOL_VERSION < 6 ) $rang = $object->line_max() + 1;
-			    $res = $object->addline($label,0,0,0,0,$qty,0,0,'','',0,0,'HT',9,$rang,false,0,null,0,0,'',TSubtotal::$module_number);
+				if ((int)DOL_VERSION < 17) {
+					$res = $object->addline($label,0,0,0,0,$qty, 0,0,'','', 0, '', 'HT', 9, $rang, false, 0, null, 0,0,'',TSubtotal::$module_number, 0,0);
+				} else {
+					$res = $object->addline($label,0,0,0,0,$qty,0,0,'','',0,0,'HT',9,$rang);
+				}
 			}
 			/**
 			 * @var $object Propal
@@ -160,8 +164,13 @@ class TSubtotal {
 			 * @var $object Commande fournisseur
 			 */
 			else if($object->element=='order_supplier') {
-				$object->special_code = TSubtotal::$module_number; // à garder pour la rétrocompatibilité
-			    $res = $object->addline($label, 0,$qty,0,0,0,0,0,'',0,'HT', 0, 9, 0, false, null, null, 0, null, 0, '', 0, -1, TSubtotal::$module_number);
+				/** @var CommandeFournisseur $object */
+			    $object->special_code = TSubtotal::$module_number;
+				if ((int)DOL_VERSION < 17) {
+					$res = $object->addline($label, 0, $qty, 0, 0, 0, 0, 0, '', 0, 'HT', 0, 9, 0, false, null, null, 0, null, 0, '', 0 ,$rang, TSubtotal::$module_number);
+				} else {
+					$res = $object->addline($label, 0,$qty,0,0,0,0,0,'',0,'HT', 0, 9);
+				}
 			}
 			/**
 			 * @var $object Facturerec


### PR DESCRIPTION
Subtotal and title lines were added as product lines because of `CommandeFournisseur::addline()` and `FactureFournisseur::addline()` changes after Dolibarr v16