### PR TITLE
- FIX : Dans le dictionnaire "Ligne de texte prédéfini" du module Sou…

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 
 # Release 3.23 - 18/12/2023
+- FIX : Dans le dictionnaire "Ligne de texte prédéfini" du module Sous total, si je tente d'éditer le contenu d'un texte, cela s'affiche en code HTML au lieu d'un champ d'édition WYSIWYG  - *27/09/2024* - 3.23.11
 - FIX : DA024939 - Added static method hasBreakPage to check if a line has a break page or not - *17/05/2024* - 3.23.10
 - FIX : DA024587 - Les totaux remisés sur le PDF Sponge sont erronés  - *20/03/2024* - 3.23.9
 - FIX : Suite a l'issue #379, la création de facture d'acompte avec un montant variable change les qté des lignes générées par le module donc on utilise un trigger pour remettre les bonnes qtés - *18/03/2024* - 3.23.8

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -68,6 +68,9 @@ class ActionsSubtotal extends \subtotal\RetroCompatCommonHookActions
 	}
 
 
+	function editDictionaryFieldlist($parameters, &$object, &$action, $hookmanager) {
+        return $this->createDictionaryFieldlist($parameters, $object, $action, $hookmanager);
+    }
 	function createDictionaryFieldlist($parameters, &$object, &$action, $hookmanager)
 	{
 		global $conf;
@@ -91,7 +94,7 @@ class ActionsSubtotal extends \subtotal\RetroCompatCommonHookActions
 				$(function() {
 
 					<?php if ((float) DOL_VERSION >= 6.0) { ?>
-							if ($('input[name=content]').length > 0)
+							if ($('input[name=content]').length > 0 || $('textarea[name=content]').length > 0)
 							{
 								$('input[name=content]').each(function(i,item) {
 									var value = '';
@@ -99,6 +102,16 @@ class ActionsSubtotal extends \subtotal\RetroCompatCommonHookActions
 									if (i == $('input[name=content]').length) value = <?php echo json_encode($value); ?>;
 									$(item).replaceWith($('<textarea name="content">'+value+'</textarea>'));
 								});
+
+                                $('textarea[name=content]').each(function(i,item) {
+                                    var value = '';
+                                    // Le dernier item correspond à l'édition
+                                    value = <?php echo json_encode($value); ?>;
+                                    $(item).replaceWith($('<textarea name="content">'+value+'</textarea>'));
+                                    console.log(value);
+
+                                });
+
 
 								<?php if (!empty($conf->fckeditor->enabled) && getDolGlobalString('FCKEDITOR_ENABLE_DETAILS')) { ?>
 								$('textarea[name=content]').each(function(i, item) {

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -66,7 +66,7 @@ class modSubtotal extends DolibarrModules
         $this->description = "Module permettant d'ajouter des titres, sous-totaux et des sous-totaux intermédiaires dans un tableau ou une liste, tout en facilitant le déplacement fluide d'une ligne d'éléments d'un sous-total à un autre.";
         // Possible values for version are: 'development', 'experimental' or version
 
-        $this->version = '3.23.10';
+        $this->version = '3.23.11';
 
 
 		// Url to the file with your last numberversion of this module


### PR DESCRIPTION
…s total, si je tente d'éditer le contenu d'un texte, cela s'affiche en code HTML au lieu d'un champ d'édition WYSIWYG  - *27/09/2024* - 3.23.11