### PR TITLE
FIX: use current() instead of array_pop() to avoid emptying the array.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 
 # Release 3.25 - 24/07/2024
+- FIX: DA025864: conf `NO_TITLE_SHOW_ON_EXPED_GENERATION` should delete all 
+  title/free/subtotal lines from the shipment but doesn't - *12/12/2024* - 3.25.5
 - FIX : DA025861 Provide an option in the heading style configuration to have no styling at all - *12/12/2024* - 3.25.4  
 - FIX DA025399 : GETPOST type integer n'existe pas - *22/08/2024* - 3.25.3
 - FIX : CKeditor no check version to avoid the error message  - *20/08/2024* - 3.25.2

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -67,7 +67,7 @@ class modSubtotal extends DolibarrModules
         // Possible values for version are: 'development', 'experimental' or version
 
 
-        $this->version = '3.25.4';
+        $this->version = '3.25.5';
 
 
 		// Url to the file with your last numberversion of this module

--- a/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
+++ b/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
@@ -475,10 +475,8 @@ class Interfacesubtotaltrigger extends DolibarrTriggers
 					if (! isset($line->special_code)) {
 						//  récuperation  de la commande generée par Trigger
 						if (count($object->linkedObjectsIds['commande']) == 1) {
-							if (! isset($cmd)) {
-								$cmd = new Commande($this->db);
-								$res = $cmd->fetch(current($object->linkedObjectsIds['commande']));
-							}
+							$cmd = new Commande($this->db);
+							$res = $cmd->fetch(array_pop($object->linkedObjectsIds['commande']));
 							if ($res > 0) {
 								$resLines = $cmd->fetch_lines();
 								if ($resLines > 0) {

--- a/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
+++ b/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
@@ -476,7 +476,7 @@ class Interfacesubtotaltrigger extends DolibarrTriggers
 						//  récuperation  de la commande generée par Trigger
 						if (count($object->linkedObjectsIds['commande']) == 1) {
 							$cmd = new Commande($this->db);
-							$res = $cmd->fetch(array_pop($object->linkedObjectsIds['commande']));
+							$res = $cmd->fetch(current($object->linkedObjectsIds['commande']));
 							if ($res > 0) {
 								$resLines = $cmd->fetch_lines();
 								if ($resLines > 0) {


### PR DESCRIPTION
+ use current() instead of array_pop() to avoid emptying the array
+ big TODO (no time now)
+ auto-reformatting (mostly for indentation)

**Après merge, prévenez-moi pour que je pull-up!**