### PR TITLE
FIX 3.25.7

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 
 # Release 3.25 - 24/07/2024
+- FIX : null-coalesce (potential fatal in trigger) + restore useful comment - *2025-03-26* - 3.25.7
 - FIX : DA025895 Refactored SHIPPING_CREATE trigger - *2025-03-26* - 3.25.6
 - FIX: DA025864: conf `NO_TITLE_SHOW_ON_EXPED_GENERATION` should delete all 
   title/free/subtotal lines from the shipment but doesn't - *12/12/2024* - 3.25.5

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -2141,7 +2141,7 @@ class ActionsSubtotal extends \subtotal\RetroCompatCommonHookActions
 
 		$this->add_numerotation($object);
 
-        foreach($object->lines as $k => &$l) {
+        foreach($object->lines ?? [] as $k => &$l) {
             if(TSubtotal::isSubtotal($l)) {
                 $parentTitle = TSubtotal::getParentTitleOfLine($object, $l->rang);
                 if(is_object($parentTitle) && empty($parentTitle->array_options)) $parentTitle->fetch_optionals();

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -67,7 +67,7 @@ class modSubtotal extends DolibarrModules
         // Possible values for version are: 'development', 'experimental' or version
 
 
-        $this->version = '3.25.6';
+        $this->version = '3.25.7';
 
 
 		// Url to the file with your last numberversion of this module

--- a/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
+++ b/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
@@ -456,15 +456,15 @@ class Interfacesubtotaltrigger extends DolibarrTriggers
 
 			// Fetch the linked order once
 			$cmd = null;
-			if (count($object->linkedObjectsIds['commande']) == 1) {
+			if (count($object->linkedObjectsIds['commande'] ?? []) === 1) {
 				$cmd = new Commande($this->db);
 				$res = $cmd->fetch(current($object->linkedObjectsIds['commande']));
 				if ($res <= 0) {
-					setEventMessage($langs->trans("ErrorLoadingLinkedOrder"), 'errors');
+					setEventMessage($langs->trans('ErrorLoadingLinkedOrder'), 'errors');
 				} else {
 					$resLines = $cmd->fetch_lines();
 					if ($resLines <= 0) {
-						setEventMessage($langs->trans("ErrorLoadingLinesFromLinkedOrder"), 'errors');
+						setEventMessage($langs->trans('ErrorLoadingLinesFromLinkedOrder'), 'errors');
 					}
 				}
 			}
@@ -476,6 +476,10 @@ class Interfacesubtotaltrigger extends DolibarrTriggers
 				$orderline->fetch($line->origin_line_id);
 
 				if (getDolGlobalString('NO_TITLE_SHOW_ON_EXPED_GENERATION')) {
+					// conf "Ne pas reporter les lignes de titre lors de la génération d’expédition"
+					// => suppression des lignes qui correspondent à un titre ou sous-total
+					// comme les lignes d'expédition n'ont pas d'attribut `special_code`, on doit le
+					// récupérer depuis les lignes de la commande.
 					if (!isset($line->special_code) && $cmd) {
 						foreach ($cmd->lines as $cmdLine) {
 							if ($cmdLine->id == $line->origin_line_id) {


### PR DESCRIPTION
- null-coalesce when objects have no `lines` attribute
- null-coalesce when a shipment has no linked order
- replace some double quotes with single quotes
- restore useful comment