### PR TITLE
PULL-UP null-coalesce

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 
 # Release 3.25 - 24/07/2024
+- FIX : null-coalesce (potential fatal in trigger) + restore useful comment - *2025-03-26* - 3.25.7
 - FIX : DA025895 Refactored SHIPPING_CREATE trigger - *2025-03-26* - 3.25.6
 - FIX: DA025864: conf `NO_TITLE_SHOW_ON_EXPED_GENERATION` should delete all 
   title/free/subtotal lines from the shipment but doesn't - *12/12/2024* - 3.25.5

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 
 # Release 3.25 - 24/07/2024
+- FIX : DA025895 Refactored SHIPPING_CREATE trigger - *2025-03-26* - 3.25.6
 - FIX: DA025864: conf `NO_TITLE_SHOW_ON_EXPED_GENERATION` should delete all 
   title/free/subtotal lines from the shipment but doesn't - *12/12/2024* - 3.25.5
 - FIX : DA025861 Provide an option in the heading style configuration to have no styling at all - *12/12/2024* - 3.25.4  

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -2141,7 +2141,7 @@ class ActionsSubtotal extends \subtotal\RetroCompatCommonHookActions
 
 		$this->add_numerotation($object);
 
-        foreach($object->lines as $k => &$l) {
+        foreach($object->lines ?? [] as $k => &$l) {
             if(TSubtotal::isSubtotal($l)) {
                 $parentTitle = TSubtotal::getParentTitleOfLine($object, $l->rang);
                 if(is_object($parentTitle) && empty($parentTitle->array_options)) $parentTitle->fetch_optionals();

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -67,7 +67,7 @@ class modSubtotal extends DolibarrModules
         // Possible values for version are: 'development', 'experimental' or version
 
 
-        $this->version = '3.25.5';
+        $this->version = '3.25.6';
 
 
 		// Url to the file with your last numberversion of this module

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -67,7 +67,7 @@ class modSubtotal extends DolibarrModules
         // Possible values for version are: 'development', 'experimental' or version
 
 
-        $this->version = '3.25.6';
+        $this->version = '3.25.7';
 
 
 		// Url to the file with your last numberversion of this module

--- a/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
+++ b/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
@@ -456,15 +456,15 @@ class Interfacesubtotaltrigger extends DolibarrTriggers
 
 			// Fetch the linked order once
 			$cmd = null;
-			if (count($object->linkedObjectsIds['commande']) == 1) {
+			if (count($object->linkedObjectsIds['commande'] ?? []) === 1) {
 				$cmd = new Commande($this->db);
 				$res = $cmd->fetch(current($object->linkedObjectsIds['commande']));
 				if ($res <= 0) {
-					setEventMessage($langs->trans("ErrorLoadingLinkedOrder"), 'errors');
+					setEventMessage($langs->trans('ErrorLoadingLinkedOrder'), 'errors');
 				} else {
 					$resLines = $cmd->fetch_lines();
 					if ($resLines <= 0) {
-						setEventMessage($langs->trans("ErrorLoadingLinesFromLinkedOrder"), 'errors');
+						setEventMessage($langs->trans('ErrorLoadingLinesFromLinkedOrder'), 'errors');
 					}
 				}
 			}
@@ -476,6 +476,10 @@ class Interfacesubtotaltrigger extends DolibarrTriggers
 				$orderline->fetch($line->origin_line_id);
 
 				if (getDolGlobalString('NO_TITLE_SHOW_ON_EXPED_GENERATION')) {
+					// conf "Ne pas reporter les lignes de titre lors de la génération d’expédition"
+					// => suppression des lignes qui correspondent à un titre ou sous-total
+					// comme les lignes d'expédition n'ont pas d'attribut `special_code`, on doit le
+					// récupérer depuis les lignes de la commande.
 					if (!isset($line->special_code) && $cmd) {
 						foreach ($cmd->lines as $cmdLine) {
 							if ($cmdLine->id == $line->origin_line_id) {

--- a/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
+++ b/core/triggers/interface_90_modSubtotal_subtotaltrigger.class.php
@@ -454,45 +454,33 @@ class Interfacesubtotaltrigger extends DolibarrTriggers
 			// on recupere la commande
 			$object->fetchObjectLinked();
 
-			// TODO: pas le temps maintenant dans le cadre du ticket DA025864, mais il faut absolument refacto
-			//       ce trigger-là.
-			//       1) on fait 2 fois le foreach, une fois pour la conf NO_TITLE_SHOW_ON_EXPED_GENERATION, une
-			//          autre fois pour supprimer les blocs sans ligne de produit.
-			//       2) on re-fetche la même commande X fois (pour chaque ligne).
-			//       3) je ne comprends pas à quoi sert le bloc à la fin du premier foreach, mais qui s'exécute
-			//          même quand la conf NO_TITLE_SHOW_ON_EXPED_GENERATION est désactivée.
+			// Fetch the linked order once
+			$cmd = null;
+			if (count($object->linkedObjectsIds['commande']) == 1) {
+				$cmd = new Commande($this->db);
+				$res = $cmd->fetch(current($object->linkedObjectsIds['commande']));
+				if ($res <= 0) {
+					setEventMessage($langs->trans("ErrorLoadingLinkedOrder"), 'errors');
+				} else {
+					$resLines = $cmd->fetch_lines();
+					if ($resLines <= 0) {
+						setEventMessage($langs->trans("ErrorLoadingLinesFromLinkedOrder"), 'errors');
+					}
+				}
+			}
+
+			$linesToDelete = [];
+
 			foreach ($object->lines as &$line) {
 				$orderline = new OrderLine($this->db);
 				$orderline->fetch($line->origin_line_id);
 
 				if (getDolGlobalString('NO_TITLE_SHOW_ON_EXPED_GENERATION')) {
-					// conf "Ne pas reporter les lignes de titre lors de la génération d’expédition"
-					// => suppression des lignes qui correspondent à un titre ou sous-total
-
-					// comme les lignes d'expédition n'ont pas d'attribut `special_code`, on doit le
-					// récupérer depuis les lignes de la commande.
-					// @todo voir plus tard pourquoi nous n'avons pas cette information dans la ligne d'expedition
-					if (! isset($line->special_code)) {
-						//  récuperation  de la commande generée par Trigger
-						if (count($object->linkedObjectsIds['commande']) == 1) {
-							$cmd = new Commande($this->db);
-							$res = $cmd->fetch(current($object->linkedObjectsIds['commande']));
-							if ($res > 0) {
-								$resLines = $cmd->fetch_lines();
-								if ($resLines > 0) {
-									foreach ($cmd->lines as $cmdLine) {
-										if ($cmdLine->id == $line->origin_line_id) {
-											$line->special_code = $cmdLine->special_code;
-											break;
-										}
-									}
-								} else {
-									//error
-									setEventMessage($langs->trans("ErrorLoadingLinesFromLinkedOrder"), 'errors');
-								}
-							} else {
-								//error
-								setEventMessage($langs->trans("ErrorLoadingLinkedOrder"), 'errors');
+					if (!isset($line->special_code) && $cmd) {
+						foreach ($cmd->lines as $cmdLine) {
+							if ($cmdLine->id == $line->origin_line_id) {
+								$line->special_code = $cmdLine->special_code;
+								break;
 							}
 						}
 					}
@@ -505,31 +493,29 @@ class Interfacesubtotaltrigger extends DolibarrTriggers
 					}
 				}
 
-				// TODO: ce `if` est à clarifier, sa pertinence à réévaluer
 				if (TSubtotal::isModSubtotalLine($orderline)) {
-					// Nous sommes sur une ligne titre, si la ligne précédente est un titre de même niveau, on supprime la ligne précédente
 					$line->special_code = TSubtotal::$module_number;
+				}
+
+				if (TSubtotal::isTitle($line)) {
+					$lines = TSubtotal::getLinesFromTitleId($object, $line->id, true);
+					$blocks = [];
+					$isThereProduct = false;
+					foreach ($lines as $lineInBlock) {
+						if (TSubtotal::isModSubtotalLine($lineInBlock)) {
+							$blocks[$lineInBlock->id] = $lineInBlock;
+						} else {
+							$isThereProduct = true;
+						}
+					}
+					if (!$isThereProduct) {
+						$linesToDelete = array_merge($linesToDelete, $blocks);
+					}
 				}
 			}
 
-			// suppression des blocs qui ne contiennent aucune ligne de produit
-			$TLinesToDelete = array();
-			foreach ($object->lines as &$line) {
-				if(TSubtotal::isTitle($line)) {
-					$TLines = TSubtotal::getLinesFromTitleId($object, $line->id, true);
-					$TBlocks = array();
-					$isThereProduct = false;
-					foreach($TLines as $lineInBlock) {
-							if(TSubtotal::isModSubtotalLine($lineInBlock) ) $TBlocks[$lineInBlock->id] = $lineInBlock;
-							else $isThereProduct = true;
-					}
-					if(!$isThereProduct) {
-						$TLinesToDelete = array_merge($TLinesToDelete, $TBlocks);
-					}
-				}
-			}
-			if (!empty($TLinesToDelete)) {
-				foreach ($TLinesToDelete as $lineToDelete) {
+			if (!empty($linesToDelete)) {
+				foreach ($linesToDelete as $lineToDelete) {
 					$lineToDelete->delete($user);
 				}
 			}


### PR DESCRIPTION
- null-coalesce when objects have no `lines` attribute
- null-coalesce when a shipment has no linked order
- replace some double quotes with single quotes
- restore useful comment