### PR TITLE
FIX DA026403: when creating a document from another (e.g. an invoice …

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 # [Unreleased]
 
 ## Release 3.28
+- FIX : DA026403 - when creating a document from another (e.g. an invoice from an order), the custom template for displaying origin product lines didn't handle free text lines + there were colspan issues - *20/05/2025* - 3.28.6
 - FIX : hook printfieldlistWhere handler used to remove subtotalLine in checkmargin  - 3.28.5
 - FIX : remove warning - *27/05/2025* - 3.28.4  
 - FIX : DA026337 - Fix buttons on supplier object - *02/04/2025* - 3.28.3

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -3641,7 +3641,7 @@ class ActionsSubtotal extends \subtotal\RetroCompatCommonHookActions
 
 				if (empty($line->label)) {
 					if ($line->qty >= 91 && $line->qty <= 99 && getDolGlobalString('CONCAT_TITLE_LABEL_IN_SUBTOTAL_LABEL')) $object->tpl["sublabel"].=  $line->description.' '.$this->getTitle($object, $line);
-					else $object->tpl["sublabel"].=  $line->description;
+					else $object->tpl["sublabel"] = ($object->tpl["sublabel"] ?? '') . $line->description;
 				}
 				else {
 

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -3589,6 +3589,7 @@ class ActionsSubtotal extends \subtotal\RetroCompatCommonHookActions
 				$object->tpl['subtotal'] = $line->id;
 				if (TSubtotal::isTitle($line)) $object->tpl['sub-type'] = 'title';
 				else if (TSubtotal::isSubtotal($line)) $object->tpl['sub-type'] = 'total';
+				else if (TSubtotal::isFreeText($line)) $object->tpl['sub-type'] = 'freetext';
 
 				$object->tpl['sub-tr-style'] = '';
 				if (getDolGlobalString('SUBTOTAL_USE_NEW_FORMAT'))

--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -67,7 +67,7 @@ class modSubtotal extends DolibarrModules
 		// Possible values for version are: 'development', 'experimental' or version
 
 
-		$this->version = '3.28.5';
+		$this->version = '3.28.6';
 
 
 		// Url to the file with your last numberversion of this module

--- a/core/tpl/originproductline.tpl.php
+++ b/core/tpl/originproductline.tpl.php
@@ -1,6 +1,6 @@
 <?php
-/* Copyright (C) 2010-2012	Regis Houssin	<regis.houssin@inodbox.com>
-/* Copyright (C) 2017		Charlie Benke	<charlie@patas-monkey.com>
+/* Copyright (C) 2010-2012  Regis Houssin  <regis.houssin@inodbox.com>
+/* Copyright (C) 2017      Charlie Benke  <charlie@patas-monkey.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,58 +17,49 @@
  */
 
 // Protection to avoid direct call of template
-if (empty($conf) || ! is_object($conf))
-{
+if (empty($conf) || ! is_object($conf)) {
 	print "Error, template page can't be called as URL";
 	exit;
 }
 
-?>
+$selected = 1;
 
-<!-- BEGIN PHP TEMPLATE originproductline.tpl.php -->
-<?php
+// invoke the core template we are overriding, but inhibit direct output: instead, store it in a variable
+ob_start();
+include DOL_DOCUMENT_ROOT.'/core/tpl/originproductline.tpl.php';
+$coreTplRow = ob_get_clean();
 
-$selected=1;
+// If this is a subtotal line: we don't print the row from the core tpl: we override it completely because we don't want
+// to show qty etc.
+if ($this->tpl['subtotal'] ?? '' == $this->tpl['id'] && in_array($this->tpl['sub-type'] ?? '', array('title', 'total', 'freetext'))) {
+	print '<tr class="oddeven'.(empty($this->tpl['strike']) ? '' : ' strikefordisabled').'" '.(! empty($this->tpl['sub-tr-style']) ? 'style="'.$this->tpl['sub-tr-style'].'"' : '').'>';
 
-if ($this->tpl['subtotal'] != $this->tpl['id'] || !in_array($this->tpl['sub-type'], array('title', 'total')))
-{
-	print '<tr data-id="'.$this->tpl['id'].'" class="oddeven'.(empty($this->tpl['strike'])?'':' strikefordisabled').'">';
-	print '<td class="linecolref">'.$this->tpl['label'].'</td>';
-	print '<td class="linecoldescription">'.$this->tpl['description'].'</td>';
-	print '<td class="linecolvat right">'.$this->tpl['vat_rate'].'</td>';
-	print '<td class="linecoluht right">'.$this->tpl['price'].'</td>';
-	if (isModEnabled('multicurrency'))
-		print '<td class="linecoluht_currency right">'.$this->tpl['multicurrency_price'].'</td>';
+	// We only use the overridden HTML to compute the colspan, but we don't print it
+	$colspan = 1; // default
+	$dom = new DOMDocument();
 
-	print '<td class="linecolqty right">'.$this->tpl['qty'].'</td>';
-	if(getDolGlobalString('PRODUCT_USE_UNITS'))
-		print '<td class="linecoluseunit left">'.$langs->trans($this->tpl['unit']).'</td>';
+	// From Gemini: suppress libxml errors in case $coreTplRow contains invalid HTML
+	libxml_use_internal_errors(true);
+	$dom->loadHTML($coreTplRow);
+	libxml_clear_errors();
+	libxml_use_internal_errors(false);
 
-	print '<td class="linecoldiscount right">'.$this->tpl['remise_percent'].'</td>';
-	// La colonne Total HT ne sera disponible qu'en 16.0, du coup tant qu'il n'y a pas de données, inutile d'afficher la td car elle n'aura pas de titre de colonne ni de valeur
-	if(!empty($this->tpl['total_ht'])) print '<td class="right">'.$this->tpl['total_ht'].'</td>';
+	$xpath = new DOMXPath($dom);
+	// Find <td> that are direct children of the first <tr>
+	$tdNodes = $xpath->query('//tr[1]/td');
+	if ($tdNodes && $tdNodes->length >= 2) {
+		$colspan = $tdNodes->length - 1; // -1 to make room for the <td> containing the checkbox
+	}
+	print '<td colspan="'.$colspan.'" '.$this->tpl['sub-td-style'].'>'.$this->tpl['sublabel'].'</td>';
 
-
-	if (!empty($selectedLines) && !in_array($this->tpl['id'], $selectedLines)) $selected=0;
+	if (! empty($selectedLines) && ! in_array($this->tpl['id'], $selectedLines)) {
+		$selected = 0;
+	}
 	print '<td class="center">';
-	print '<input id="cb'.$this->tpl['id'].'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$this->tpl['id'].'"'.($selected?' checked="checked"':'').'>';
+	print '<input id="cb'.$this->tpl['id'].'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$this->tpl['id'].'"'.($selected ? ' checked="checked"' : '').'>';
 	print '</td>';
 	print '</tr>'."\n";
-}
-else
-{
-	$colspan = 6;
-	if (isModEnabled('multicurrency')) $colspan++;
-    if(getDolGlobalString('PRODUCT_USE_UNITS')) $colspan++;
-	print '<tr class="oddeven'.(empty($this->tpl['strike'])?'':' strikefordisabled').'" '.(!empty($this->tpl['sub-tr-style']) ? 'style="'.$this->tpl['sub-tr-style'].'"' : '').'>';
-	print '<td colspan="'.$colspan.'" '.$this->tpl['sub-td-style'].'>'.$this->tpl["sublabel"].'</td>';
-
-	if (!empty($selectedLines) && !in_array($this->tpl['id'], $selectedLines)) $selected=0;
-	print '<td class="center">';
-	print '<input id="cb'.$this->tpl['id'].'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$this->tpl['id'].'"'.($selected?' checked="checked"':'').'>';
-	print '</td>';
-	print '</tr>'."\n";
-
+} else {
+	print $coreTplRow;
 }
 ?>
-<!-- END PHP TEMPLATE originproductline.tpl.php -->


### PR DESCRIPTION
…from an order), the custom template for displaying origin product lines didn't handle free text lines + there were colspan issues sometimes

### Before
<img width="939" height="311" alt="image" src="https://github.com/user-attachments/assets/521d588c-d774-4bfd-bccc-bb77eadf909b" />

### After
<img width="940" height="237" alt="image" src="https://github.com/user-attachments/assets/d1ccc8e3-90f9-439b-bc3e-d6b55edbb6d5" />
